### PR TITLE
task executor deprecated & some refactoring

### DIFF
--- a/java-server-spring/src/main/java/com/canoo/dolphin/server/spring/SpringContainerManager.java
+++ b/java-server-spring/src/main/java/com/canoo/dolphin/server/spring/SpringContainerManager.java
@@ -17,7 +17,6 @@ package com.canoo.dolphin.server.spring;
 
 import com.canoo.dolphin.server.container.ContainerManager;
 import com.canoo.dolphin.server.container.ModelInjector;
-import com.canoo.dolphin.server.context.DolphinContext;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
@@ -33,12 +32,15 @@ import javax.servlet.ServletContext;
  */
 public class SpringContainerManager implements ContainerManager {
 
+    private ServletContext servletContext;
+
     @Override
     public void init(ServletContext servletContext) {
         if(servletContext == null) {
             throw new IllegalArgumentException("servletContext must not be null!");
         }
-        WebApplicationContext context = getContext(servletContext);
+        this.servletContext = servletContext;
+        WebApplicationContext context = getContext();
         DefaultListableBeanFactory beanFactory = (DefaultListableBeanFactory) context.getAutowireCapableBeanFactory();
         beanFactory.addBeanPostProcessor(SpringModelInjector.getInstance());
     }
@@ -52,7 +54,7 @@ public class SpringContainerManager implements ContainerManager {
             throw new IllegalArgumentException("modelInjector must not be null!");
         }
         // SpringBeanAutowiringSupport kann man auch nutzen
-        WebApplicationContext context = getContext(DolphinContext.getCurrentContext().getServletContext());
+        WebApplicationContext context = getContext();
         AutowireCapableBeanFactory beanFactory = context.getAutowireCapableBeanFactory();
         SpringModelInjector.getInstance().prepare(controllerClass, modelInjector);
         return beanFactory.createBean(controllerClass);
@@ -63,7 +65,7 @@ public class SpringContainerManager implements ContainerManager {
         if(instance == null) {
             throw new IllegalArgumentException("instance must not be null!");
         }
-        ApplicationContext context = getContext(DolphinContext.getCurrentContext().getServletContext());
+        ApplicationContext context = getContext();
         context.getAutowireCapableBeanFactory().destroyBean(instance);
     }
 
@@ -72,10 +74,7 @@ public class SpringContainerManager implements ContainerManager {
      *
      * @return the spring context
      */
-    private WebApplicationContext getContext(ServletContext servletContext) {
-        if(servletContext == null) {
-            throw new IllegalArgumentException("servletContext must not be null!");
-        }
+    private WebApplicationContext getContext() {
         return WebApplicationContextUtils.getWebApplicationContext(servletContext);
     }
 }

--- a/java-server/src/main/java/com/canoo/dolphin/server/event/TaskExecutor.java
+++ b/java-server/src/main/java/com/canoo/dolphin/server/event/TaskExecutor.java
@@ -39,6 +39,7 @@ import java.io.Serializable;
  * easily be shared and edited between several clients in realtime.
  *</p>
  */
+@Deprecated
 public interface TaskExecutor extends Serializable {
 
     public <T> void execute(Class<T> controllerClass, ControllerTask<T> task);

--- a/java-server/src/main/java/com/canoo/dolphin/server/event/impl/DolphinContextTaskExecutor.java
+++ b/java-server/src/main/java/com/canoo/dolphin/server/event/impl/DolphinContextTaskExecutor.java
@@ -29,6 +29,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 @ThreadSafe
+@Deprecated
 public class DolphinContextTaskExecutor {
 
     @GuardedBy("tasksMapLock")

--- a/java-server/src/main/java/com/canoo/dolphin/server/event/impl/TaskExecutorImpl.java
+++ b/java-server/src/main/java/com/canoo/dolphin/server/event/impl/TaskExecutorImpl.java
@@ -20,18 +20,10 @@ import com.canoo.dolphin.server.context.DolphinContextHandler;
 import com.canoo.dolphin.server.event.ControllerTask;
 import com.canoo.dolphin.server.event.TaskExecutor;
 
-import javax.annotation.concurrent.GuardedBy;
-import javax.annotation.concurrent.ThreadSafe;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
-/**
- * Created by hendrikebbers on 15.09.15.
- */
+@Deprecated
 public class TaskExecutorImpl implements TaskExecutor {
 
     private static TaskExecutorImpl Instance = new TaskExecutorImpl();

--- a/java-server/src/main/java/com/canoo/dolphin/server/event/impl/TaskTrigger.java
+++ b/java-server/src/main/java/com/canoo/dolphin/server/event/impl/TaskTrigger.java
@@ -15,8 +15,6 @@
  */
 package com.canoo.dolphin.server.event.impl;
 
-/**
- * Created by hendrikebbers on 15.09.15.
- */
+@Deprecated
 public interface TaskTrigger {
 }


### PR DESCRIPTION
All classes / interfaces of the task executor are deprecated and can be removed in the next version.
The DolphinContext don't depend on the servant context / servlet API anymore that will make testing much easier.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/62)
<!-- Reviewable:end -->
