### PR TITLE
Fix for memory leak

### DIFF
--- a/java-server/src/main/java/com/canoo/dolphin/server/servlet/DolphinPlatformBootstrap.java
+++ b/java-server/src/main/java/com/canoo/dolphin/server/servlet/DolphinPlatformBootstrap.java
@@ -51,8 +51,8 @@ public class DolphinPlatformBootstrap {
         servletContext.addServlet(DOLPHIN_INVALIDATION_SERVLET_NAME, new InvalidationServlet()).addMapping(dolphinInvalidationServletMapping);
         servletContext.addFilter(DOLPHIN_CROSS_SITE_FILTER_NAME, new CrossSiteOriginFilter()).addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
 
-        servletContext.addListener(new DolphinSessionHandlerCleaner());
         servletContext.addListener(new DolphinContextCleaner());
+        servletContext.addListener(new DolphinSessionHandlerCleaner());
 
         ControllerRepository.init();
 


### PR DESCRIPTION
Change order of listener registration, because the listeners are called in reverse order when the session is destroyed and DolphinSessionHandlerCleaner requires the DolphinContext to be intact.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/68)
<!-- Reviewable:end -->
