### PR TITLE
Adding a type conversion for the payload of Property based attributes

### DIFF
--- a/java-core/src/main/java/com/canoo/dolphin/impl/ClassRepositoryImpl.java
+++ b/java-core/src/main/java/com/canoo/dolphin/impl/ClassRepositoryImpl.java
@@ -106,15 +106,17 @@ public class ClassRepositoryImpl implements ClassRepository {
 
         for (Field field : ReflectionHelper.getInheritedDeclaredFields(beanClass)) {
             PropertyType type = null;
+            Class nestingType = null;
             if (Property.class.isAssignableFrom(field.getType())) {
                 type = PropertyType.PROPERTY;
+                nestingType = ReflectionHelper.getNestingType(field.getGenericType());
             } else if (ObservableList.class.isAssignableFrom(field.getType())) {
                 type = PropertyType.OBSERVABLE_LIST;
             }
             if (type != null) {
                 final String attributeName = DolphinUtils.getDolphinAttributePropertyNameForField(field);
                 final Attribute attribute = model.findAttributeByPropertyName(attributeName);
-                final PropertyInfo propertyInfo = new ClassPropertyInfo(attribute, attributeName, initialConverter, field);
+                final PropertyInfo propertyInfo = new ClassPropertyInfo(attribute, attributeName, initialConverter, field, nestingType);
                 if (type == PropertyType.PROPERTY) {
                     propertyInfos.add(propertyInfo);
                 } else {

--- a/java-core/src/main/java/com/canoo/dolphin/impl/ReflectionHelper.java
+++ b/java-core/src/main/java/com/canoo/dolphin/impl/ReflectionHelper.java
@@ -16,12 +16,13 @@
 package com.canoo.dolphin.impl;
 
 import com.canoo.dolphin.mapping.Property;
-
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -130,5 +131,15 @@ public class ReflectionHelper {
 
     public static boolean isProxyInstance(Object bean) {
         return Proxy.isProxyClass(bean.getClass());
+    }
+
+    public static Class getNestingType(Type type) {
+        if (type instanceof  ParameterizedType) {
+            ParameterizedType pType = (ParameterizedType) type;
+            if (pType.getActualTypeArguments().length > 0) {
+                return (Class) pType.getActualTypeArguments()[0];
+            }
+        }
+        return null;
     }
 }

--- a/java-core/src/main/java/com/canoo/dolphin/impl/info/ClassPropertyInfo.java
+++ b/java-core/src/main/java/com/canoo/dolphin/impl/info/ClassPropertyInfo.java
@@ -18,6 +18,7 @@ package com.canoo.dolphin.impl.info;
 import com.canoo.dolphin.impl.Converters;
 import com.canoo.dolphin.impl.ReflectionHelper;
 import com.canoo.dolphin.internal.info.PropertyInfo;
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 import org.opendolphin.core.Attribute;
 
 import java.lang.reflect.Field;
@@ -25,10 +26,16 @@ import java.lang.reflect.Field;
 public class ClassPropertyInfo extends PropertyInfo {
 
     private final Field field;
+    private final Class nestingType;
 
     public ClassPropertyInfo(Attribute attribute, String attributeName, Converters.Converter converter, Field field) {
+        this(attribute, attributeName, converter, field, null);
+    }
+
+    public ClassPropertyInfo(Attribute attribute, String attributeName, Converters.Converter converter, Field field, Class nestingType) {
         super(attribute, attributeName, converter);
         this.field = field;
+        this.nestingType = nestingType;
     }
 
     @Override
@@ -41,4 +48,20 @@ public class ClassPropertyInfo extends PropertyInfo {
         ReflectionHelper.setPrivileged(field, bean, value);
     }
 
+    @Override
+    public Object convertFromDolphin(Object value) {
+        value = super.convertFromDolphin(value);
+        if (nestingType != null) {
+            value = DefaultTypeTransformation.castToType(value, nestingType);
+        }
+        return value;
+    }
+
+    @Override
+    public Object convertToDolphin(Object value) {
+        if (nestingType != null) {
+            value = DefaultTypeTransformation.castToType(value, nestingType);
+        }
+        return super.convertToDolphin(value);
+    }
 }


### PR DESCRIPTION
This pull request is more thought as an idea and for discussion, not for actual merging!

I am trying to address part of #97 and related issues like a long being transported as an int and then failing on the client or server side. In this pullrequest the value will be converted using the type conversion construct from Groovy, which allows to convert any Number type to any Number type, as well as converting between string and enum... of course it does a lot more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/136)
<!-- Reviewable:end -->
