### PR TITLE
Deactivate the invalidation servlet

### DIFF
--- a/documentation/dolphin-platform-documentation/src/docs/asciidoc/server-configuration.adoc
+++ b/documentation/dolphin-platform-documentation/src/docs/asciidoc/server-configuration.adoc
@@ -26,6 +26,12 @@ Currently the following properties are supported by the Dolphin Platform:
 |true, false
 |true
 
+|useSessionInvalidationServlet
+|Boolean property that defines if the servlet for session validation should be used. By default the servlet will not be used. We plan to remove the servlet completelly in a future release and this property is just for a fallback if not using the servelt will end in issues.
+|true, false
+|false
+
+
 |servletMapping
 |A string based property that defines the server URL endpoint for the Dolphin Platform.
 |any String that defines an URL mapping

--- a/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/config/DolphinPlatformConfiguration.java
+++ b/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/config/DolphinPlatformConfiguration.java
@@ -27,6 +27,8 @@ public class DolphinPlatformConfiguration {
 
     private boolean useCrossSiteOriginFilter = true;
 
+    private boolean useSessionInvalidationServlet = false;
+
     private boolean garbageCollectionActive = false;
 
     private String dolphinPlatformServletMapping = "/dolphin";
@@ -63,5 +65,13 @@ public class DolphinPlatformConfiguration {
 
     public void setGarbageCollectionActive(boolean garbageCollectionActive) {
         this.garbageCollectionActive = garbageCollectionActive;
+    }
+
+    public boolean isUseSessionInvalidationServlet() {
+        return useSessionInvalidationServlet;
+    }
+
+    public void setUseSessionInvalidationServlet(boolean useSessionInvalidationServlet) {
+        this.useSessionInvalidationServlet = useSessionInvalidationServlet;
     }
 }

--- a/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/impl/ConfigurationFileLoader.java
+++ b/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/impl/ConfigurationFileLoader.java
@@ -49,6 +49,8 @@ public class ConfigurationFileLoader {
 
     private static final String USE_CROSS_SITE_ORIGIN_FILTER = "useCrossSiteOriginFilter";
 
+    private static final String USE_SESSION_INVALIDATION_SERVLET= "useSessionInvalidationServlet";
+
     private static final String GARBAGE_COLLECTION_ACTIVE = "garbageCollectionActive";
 
     /**
@@ -115,6 +117,11 @@ public class ConfigurationFileLoader {
         if(prop.containsKey(USE_CROSS_SITE_ORIGIN_FILTER)) {
             configuration.setUseCrossSiteOriginFilter(Boolean.parseBoolean(prop.getProperty(DOLPHIN_PLATFORM_SERVLET_MAPPING)));
         }
+
+        if(prop.containsKey(USE_SESSION_INVALIDATION_SERVLET)) {
+            configuration.setUseSessionInvalidationServlet(Boolean.parseBoolean(prop.getProperty(USE_SESSION_INVALIDATION_SERVLET)));
+        }
+
 
         if(prop.containsKey(GARBAGE_COLLECTION_ACTIVE)) {
             UnstableFeatureFlags.setUseGc(Boolean.parseBoolean(prop.getProperty(GARBAGE_COLLECTION_ACTIVE)));

--- a/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/servlet/DolphinPlatformBootstrap.java
+++ b/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/servlet/DolphinPlatformBootstrap.java
@@ -100,12 +100,13 @@ public class DolphinPlatformBootstrap {
         dolphinContextHandlerFactory = new DolphinContextHandlerFactoryImpl();
         dolphinContextHandler = dolphinContextHandlerFactory.create(configuration, controllerRepository, containerManager);
 
-
         servletContext.addServlet(DOLPHIN_SERVLET_NAME, new DolphinPlatformServlet(dolphinContextHandler)).addMapping(configuration.getDolphinPlatformServletMapping());
-        servletContext.addServlet(DOLPHIN_INVALIDATION_SERVLET_NAME, new InvalidationServlet()).addMapping(DEFAULT_DOLPHIN_INVALIDATION_SERVLET_MAPPING);
-
         LOG.debug("Dolphin Platform initialized under context \"" + servletContext.getContextPath() + "\"");
         LOG.debug("Dolphin Platform endpoint defined as " + configuration.getDolphinPlatformServletMapping());
+
+        if(configuration.isUseSessionInvalidationServlet()) {
+            servletContext.addServlet(DOLPHIN_INVALIDATION_SERVLET_NAME, new InvalidationServlet()).addMapping(DEFAULT_DOLPHIN_INVALIDATION_SERVLET_MAPPING);
+        }
 
         if (configuration.isUseCrossSiteOriginFilter()) {
             servletContext.addFilter(DOLPHIN_CROSS_SITE_FILTER_NAME, new CrossSiteOriginFilter()).addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");


### PR DESCRIPTION
Since 0.8.5 we don't use the invalidation servlet anymore. With this change it will be deactivated by default but can be activated by using the dolphin.properties
If everything works well we can remove the servlet completely in a later version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/188)
<!-- Reviewable:end -->
