### PR TITLE
Bugfix for controller tests that support Session Scope in controllers

### DIFF
--- a/platform-extras/dolphin-platform-spring-controller-tester/src/main/java/com/canoo/dolphin/test/impl/TestInMemoryConfiguration.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/main/java/com/canoo/dolphin/test/impl/TestInMemoryConfiguration.java
@@ -3,6 +3,7 @@ package com.canoo.dolphin.test.impl;
 import org.opendolphin.core.client.ClientDolphin;
 import org.opendolphin.core.client.ClientModelStore;
 import org.opendolphin.core.client.comm.InMemoryClientConnector;
+import org.opendolphin.core.client.comm.SynchronousInMemoryClientConnector;
 import org.opendolphin.core.client.comm.UiThreadHandler;
 import org.opendolphin.core.server.DefaultServerDolphin;
 import org.opendolphin.core.server.ServerDolphinFactory;
@@ -22,7 +23,7 @@ public class TestInMemoryConfiguration {
 
         clientDolphin.setClientModelStore(new ClientModelStore(clientDolphin));
 
-        InMemoryClientConnector inMemoryClientConnector = new InMemoryClientConnector(clientDolphin, serverDolphin.getServerConnector());
+        InMemoryClientConnector inMemoryClientConnector = new SynchronousInMemoryClientConnector(clientDolphin, serverDolphin.getServerConnector());
 
         inMemoryClientConnector.setSleepMillis(0);
         clientDolphin.setClientConnector(inMemoryClientConnector);

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/ClientService.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/ClientService.java
@@ -1,0 +1,21 @@
+package com.canoo.dolphin.test.scopes;
+
+import com.canoo.dolphin.server.spring.ClientScoped;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@ClientScoped
+public class ClientService {
+
+    private final String id;
+
+    public ClientService() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/RequestService.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/RequestService.java
@@ -1,0 +1,21 @@
+package com.canoo.dolphin.test.scopes;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@Scope("request")
+public class RequestService {
+
+    private final String id;
+
+    public RequestService() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/ScopeModel.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/ScopeModel.java
@@ -1,0 +1,32 @@
+package com.canoo.dolphin.test.scopes;
+
+import com.canoo.dolphin.mapping.DolphinBean;
+import com.canoo.dolphin.mapping.Property;
+
+@DolphinBean
+public class ScopeModel {
+
+    private Property<String> requestServiceId;
+
+    private Property<String> clientServiceId;
+
+    private Property<String> sessionServiceId;
+
+    private Property<String> singletonServiceId;
+
+    public Property<String> requestServiceIdProperty() {
+        return requestServiceId;
+    }
+
+    public Property<String> clientServiceIdProperty() {
+        return clientServiceId;
+    }
+
+    public Property<String>sessionServiceIdProperty() {
+        return sessionServiceId;
+    }
+
+    public Property<String> singletonServiceIdProperty() {
+        return singletonServiceId;
+    }
+}

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/ScopeTestController.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/ScopeTestController.java
@@ -1,0 +1,34 @@
+package com.canoo.dolphin.test.scopes;
+
+import com.canoo.dolphin.server.DolphinController;
+import com.canoo.dolphin.server.DolphinModel;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+@DolphinController("ScopeTestController")
+public class ScopeTestController {
+
+    @Inject
+    private RequestService requestService;
+
+    @Inject
+    private ClientService clientService;
+
+    @Inject
+    private SessionService sessionService;
+
+    @Inject
+    private SingletonService singletonService;
+
+    @DolphinModel
+    private ScopeModel model;
+
+    @PostConstruct
+    public void init() {
+        model.requestServiceIdProperty().set(requestService.getId());
+        model.clientServiceIdProperty().set(clientService.getId());
+        model.sessionServiceIdProperty().set(sessionService.getId());
+        model.singletonServiceIdProperty().set(singletonService.getId());
+    }
+}

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/ScopeTestControllerTest.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/ScopeTestControllerTest.java
@@ -1,0 +1,48 @@
+package com.canoo.dolphin.test.scopes;
+
+import com.canoo.dolphin.test.ControllerUnderTest;
+import com.canoo.dolphin.test.SpringTestNGControllerTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+@SpringApplicationConfiguration(classes = ScopesConfig.class)
+public class ScopeTestControllerTest extends SpringTestNGControllerTest {
+
+    @Inject
+    private RequestService requestService;
+
+    @Inject
+    private ClientService clientService;
+
+    @Inject
+    private SessionService sessionService;
+
+    @Inject
+    private SingletonService singletonService;
+
+    @Test
+    public void testAllScopes() {
+        ControllerUnderTest<ScopeModel> controller = createController("ScopeTestController");
+
+        Assert.assertTrue(requestService.getId() != null);
+        Assert.assertTrue(controller.getModel().requestServiceIdProperty().get() != null);
+        Assert.assertTrue(requestService.getId().equals(controller.getModel().requestServiceIdProperty().get()));
+
+        Assert.assertTrue(clientService.getId() != null);
+        Assert.assertTrue(controller.getModel().clientServiceIdProperty().get() != null);
+        Assert.assertTrue(clientService.getId().equals(controller.getModel().clientServiceIdProperty().get()));
+
+        Assert.assertTrue(sessionService.getId() != null);
+        Assert.assertTrue(controller.getModel().sessionServiceIdProperty().get() != null);
+        Assert.assertTrue(sessionService.getId().equals(controller.getModel().sessionServiceIdProperty().get()));
+
+        Assert.assertTrue(singletonService.getId() != null);
+        Assert.assertTrue(controller.getModel().singletonServiceIdProperty().get() != null);
+        Assert.assertTrue(singletonService.getId().equals(controller.getModel().singletonServiceIdProperty().get()));
+
+        controller.destroy();
+    }
+}

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/ScopesConfig.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/ScopesConfig.java
@@ -1,0 +1,11 @@
+package com.canoo.dolphin.test.scopes;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+@EnableAutoConfiguration
+public class ScopesConfig {
+}

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/SessionService.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/SessionService.java
@@ -1,0 +1,21 @@
+package com.canoo.dolphin.test.scopes;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@Scope("session")
+public class SessionService {
+
+    private final String id;
+
+    public SessionService() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/SingletonService.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/test/java/com/canoo/dolphin/test/scopes/SingletonService.java
@@ -1,0 +1,22 @@
+package com.canoo.dolphin.test.scopes;
+
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+public class SingletonService {
+
+    private final String id;
+
+    public SingletonService() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    public String getId() {
+        return id;
+    }
+}


### PR DESCRIPTION
Currently session (and request) scope is not supported in controller tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/206)
<!-- Reviewable:end -->
