### PR TITLE
use URL instead of String in Java Client

### DIFF
--- a/platform-examples/todo-example/todo-client/src/main/java/com/canoo/dolphin/todo/client/ToDoClient.java
+++ b/platform-examples/todo-example/todo-client/src/main/java/com/canoo/dolphin/todo/client/ToDoClient.java
@@ -33,20 +33,28 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 public class ToDoClient extends DolphinPlatformApplication {
 
     @Override
-    protected String getServerEndpoint() {
-        return "http://localhost:8080/todo-app/dolphin";
+    protected URL getServerEndpoint() {
+        URL url = null;
+        try {
+            url = new URL("http://localhost:8080/todo-app/dolphin");
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Exception while creating URL", e);
+        }
+        return url;
     }
 
     @Override
     protected void start(Stage primaryStage, ClientContext clientContext) throws Exception {
         clientContext.onRemotingError(e -> {
-            if(e.getCause() != null && e.getCause() instanceof DolphinSessionException) {
+            if (e.getCause() != null && e.getCause() instanceof DolphinSessionException) {
                 showError("A remoting error happened", "Looks like we ended in a session timeout :(", e);
-            } else if(e.getCause() != null && e.getCause() instanceof HttpResponseException) {
+            } else if (e.getCause() != null && e.getCause() instanceof HttpResponseException) {
                 showError("A remoting error happened", "Looks like the server sended a bad response :(", e);
             } else {
                 showError("A remoting error happened", "Looks like we have a big problem :(", e);

--- a/platform-examples/todo-example/todo-client/src/main/java/com/canoo/dolphin/todo/client/ToDoClient.java
+++ b/platform-examples/todo-example/todo-client/src/main/java/com/canoo/dolphin/todo/client/ToDoClient.java
@@ -39,14 +39,8 @@ import java.net.URL;
 public class ToDoClient extends DolphinPlatformApplication {
 
     @Override
-    protected URL getServerEndpoint() {
-        URL url = null;
-        try {
-            url = new URL("http://localhost:8080/todo-app/dolphin");
-        } catch (MalformedURLException e) {
-            throw new RuntimeException("Exception while creating URL", e);
-        }
-        return url;
+    protected URL getServerEndpoint() throws MalformedURLException {
+        return new URL("http://localhost:8080/todo-app/dolphin");
     }
 
     @Override

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/main/java/com/canoo/dolphin/test/impl/DolphinPlatformSpringTestBootstrap.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/main/java/com/canoo/dolphin/test/impl/DolphinPlatformSpringTestBootstrap.java
@@ -64,17 +64,20 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 @Configuration
 public class DolphinPlatformSpringTestBootstrap {
 
     @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
-    public ClientContext createClientContext(final DolphinTestContext dolphinContext, final TestInMemoryConfiguration config) throws ExecutionException, InterruptedException {
+    public ClientContext createClientContext(final DolphinTestContext dolphinContext, final TestInMemoryConfiguration config) throws ExecutionException, InterruptedException, MalformedURLException {
         Assert.requireNonNull(dolphinContext, "dolphinContext");
         final ClientDolphin clientDolphin = dolphinContext.getClientDolphin();
 
-        final ClientConfiguration clientConfiguration = new ClientConfiguration("PIPE", new UiThreadHandler() {
+        final URL dummyURL = new URL("http://dummyURL");
+        final ClientConfiguration clientConfiguration = new ClientConfiguration(dummyURL, new UiThreadHandler() {
 
             @Override
             public void executeInsideUiThread(Runnable runnable) {
@@ -97,13 +100,13 @@ public class DolphinPlatformSpringTestBootstrap {
         final ClientContext clientContext = new ClientContextImpl(clientConfiguration, clientDolphin, controllerProxyFactory, dolphinCommandHandler, platformBeanRepository, clientBeanManager, new ForwardableCallback());
 
         //Currently the event bus can not used in tests. See https://github.com/canoo/dolphin-platform/issues/196
-     //   config.getClientExecutor().submit(new Runnable() {
-     //       @Override
-     //       public void run() {
-     //           clientDolphin.startPushListening(PlatformConstants.POLL_EVENT_BUS_COMMAND_NAME, PlatformConstants.RELEASE_EVENT_BUS_COMMAND_NAME);
-     //       }
+        //   config.getClientExecutor().submit(new Runnable() {
+        //       @Override
+        //       public void run() {
+        //           clientDolphin.startPushListening(PlatformConstants.POLL_EVENT_BUS_COMMAND_NAME, PlatformConstants.RELEASE_EVENT_BUS_COMMAND_NAME);
+        //       }
 //
-  //      }).get();
+        //      }).get();
         return clientContext;
     }
 
@@ -170,7 +173,7 @@ public class DolphinPlatformSpringTestBootstrap {
         return context.getDolphinEventBus();
     }
 
-    @Bean(name="propertyBinder")
+    @Bean(name = "propertyBinder")
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
     protected PropertyBinder createPropertyBinder() {
         return new PropertyBinderImpl();

--- a/platform/dolphin-platform-client-javafx/src/main/java/com/canoo/dolphin/client/javafx/DolphinPlatformApplication.java
+++ b/platform/dolphin-platform-client-javafx/src/main/java/com/canoo/dolphin/client/javafx/DolphinPlatformApplication.java
@@ -27,6 +27,7 @@ import javafx.stage.Stage;
 
 import java.util.concurrent.TimeUnit;
 import java.net.URL;
+import java.net.MalformedURLException;
 
 /**
  * Defines a basic application class for Dolphin Platform based applications that can be used like the {@link Application}
@@ -58,14 +59,20 @@ public abstract class DolphinPlatformApplication extends Application {
      * @return The Dolphin Platform configuration for this client
      */
     protected JavaFXConfiguration getClientConfiguration() {
-        return new JavaFXConfiguration(getServerEndpoint());
+        JavaFXConfiguration configuration = null;
+        try {
+            configuration = new JavaFXConfiguration(getServerEndpoint());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Malformed URL exception while creating configuration", e);
+        }
+        return configuration;
     }
 
     /**
      * Returns the server url of the Dolphin Platform server endpoint.
      * @return the server url
      */
-    protected abstract URL getServerEndpoint();
+    protected abstract URL getServerEndpoint() throws MalformedURLException;
 
     /**
      * This methods defines parts of the Dolphin Platform lifecyycle and is therefore defined as final.

--- a/platform/dolphin-platform-client-javafx/src/main/java/com/canoo/dolphin/client/javafx/DolphinPlatformApplication.java
+++ b/platform/dolphin-platform-client-javafx/src/main/java/com/canoo/dolphin/client/javafx/DolphinPlatformApplication.java
@@ -63,7 +63,7 @@ public abstract class DolphinPlatformApplication extends Application {
         try {
             configuration = new JavaFXConfiguration(getServerEndpoint());
         } catch (MalformedURLException e) {
-            throw new RuntimeException("Malformed URL exception while creating configuration", e);
+            throw new ClientInitializationException("Client configuration cannot be created", e);
         }
         return configuration;
     }
@@ -84,7 +84,7 @@ public abstract class DolphinPlatformApplication extends Application {
     public final void start(final Stage primaryStage) throws Exception {
         Assert.requireNonNull(primaryStage, "primaryStage");
         if (initializationException == null) {
-            if(clientContext != null) {
+            if (clientContext != null) {
                 clientContext.onRemotingError(e -> onRemotingError(primaryStage, e));
                 start(primaryStage, clientContext);
             } else {
@@ -123,7 +123,7 @@ public abstract class DolphinPlatformApplication extends Application {
      */
     @Override
     public final void stop() throws Exception {
-        if(clientContext != null) {
+        if (clientContext != null) {
             try {
                 clientContext.disconnect().get(2, TimeUnit.SECONDS);
                 onShutdown();
@@ -163,7 +163,7 @@ public abstract class DolphinPlatformApplication extends Application {
      * This method will be called in the {@link Application#stop()} method after the connection to the Dolphin
      * Platform server is closed. Application developers can define some kind of close handling here.
      *
-     *  By default the methods calls {@link System#exit(int)}
+     * By default the methods calls {@link System#exit(int)}
      */
     protected void onShutdown() {
         System.exit(0);

--- a/platform/dolphin-platform-client-javafx/src/main/java/com/canoo/dolphin/client/javafx/DolphinPlatformApplication.java
+++ b/platform/dolphin-platform-client-javafx/src/main/java/com/canoo/dolphin/client/javafx/DolphinPlatformApplication.java
@@ -26,6 +26,7 @@ import javafx.application.Platform;
 import javafx.stage.Stage;
 
 import java.util.concurrent.TimeUnit;
+import java.net.URL;
 
 /**
  * Defines a basic application class for Dolphin Platform based applications that can be used like the {@link Application}
@@ -64,7 +65,7 @@ public abstract class DolphinPlatformApplication extends Application {
      * Returns the server url of the Dolphin Platform server endpoint.
      * @return the server url
      */
-    protected abstract String getServerEndpoint();
+    protected abstract URL getServerEndpoint();
 
     /**
      * This methods defines parts of the Dolphin Platform lifecyycle and is therefore defined as final.

--- a/platform/dolphin-platform-client-javafx/src/main/java/com/canoo/dolphin/client/javafx/JavaFXConfiguration.java
+++ b/platform/dolphin-platform-client-javafx/src/main/java/com/canoo/dolphin/client/javafx/JavaFXConfiguration.java
@@ -15,6 +15,8 @@
  */
 package com.canoo.dolphin.client.javafx;
 
+import java.net.URL;
+
 import com.canoo.dolphin.client.ClientConfiguration;
 import javafx.application.Platform;
 
@@ -23,7 +25,7 @@ import javafx.application.Platform;
  */
 public class JavaFXConfiguration extends ClientConfiguration {
 
-    public JavaFXConfiguration(String serverEndpoint) {
+    public JavaFXConfiguration(URL serverEndpoint) {
         super(serverEndpoint, r -> Platform.runLater(r));
     }
 }

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/ClientConfiguration.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/ClientConfiguration.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.logging.Level;
+import java.net.URL;
 
 /**
  * Configuration class for a Dolphin Platform client. A configuration is needed to create a {@link ClientContext} by
@@ -39,7 +40,7 @@ public class ClientConfiguration {
 
     private final static long DEFAULT_CONNECTION_TIMEOUT = 5000;
 
-    private final String serverEndpoint;
+    private final URL serverEndpoint;
 
     private final UiThreadHandler uiThreadHandler;
 
@@ -54,11 +55,11 @@ public class ClientConfiguration {
     /**
      * Default constructor of a client configuration
      *
-     * @param serverEndpoint  the DOlphin Platform server url
+     * @param serverEndpoint the DOlphin Platform server url
      * @param uiThreadHandler the ui thread handler
      */
-    public ClientConfiguration(String serverEndpoint, UiThreadHandler uiThreadHandler) {
-        this.serverEndpoint = Assert.requireNonBlank(serverEndpoint, "serverEndpoint");
+    public ClientConfiguration(URL serverEndpoint, UiThreadHandler uiThreadHandler) {
+        this.serverEndpoint = Assert.requireNonNull(serverEndpoint, "serverEndpoint");
         this.uiThreadHandler = Assert.requireNonNull(uiThreadHandler, "uiThreadHandler");
         this.dolphinLogLevel = Level.SEVERE;
         this.connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
@@ -80,7 +81,7 @@ public class ClientConfiguration {
      *
      * @return the server endpoint
      */
-    public String getServerEndpoint() {
+    public URL getServerEndpoint() {
         return serverEndpoint;
     }
 
@@ -131,6 +132,6 @@ public class ClientConfiguration {
     }
 
     public void setHttpClient(HttpClient httpClient) {
-        this.httpClient =  Assert.requireNonNull(httpClient, "httpClient");
+        this.httpClient = Assert.requireNonNull(httpClient, "httpClient");
     }
 }

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/DolphinPlatformHttpClientConnector.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/DolphinPlatformHttpClientConnector.java
@@ -30,6 +30,7 @@ import org.opendolphin.core.comm.Command;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.net.URL;
 
 /**
  * This class is used to sync the unique client scope id of the current dolphin
@@ -38,7 +39,7 @@ public class DolphinPlatformHttpClientConnector extends AbstractClientConnector 
 
     private static final String CHARSET = "UTF-8";
 
-    private final String servletUrl;
+    private final URL servletUrl;
 
     private final HttpClient httpClient;
 
@@ -50,7 +51,7 @@ public class DolphinPlatformHttpClientConnector extends AbstractClientConnector 
 
     private String clientId;
 
-    public DolphinPlatformHttpClientConnector(ClientDolphin clientDolphin, Codec codec, HttpClient httpClient, String servletUrl, ForwardableCallback<DolphinRemotingException> remotingErrorHandler, UiThreadHandler uiThreadHandler) {
+    public DolphinPlatformHttpClientConnector(ClientDolphin clientDolphin, Codec codec, HttpClient httpClient, URL servletUrl, ForwardableCallback<DolphinRemotingException> remotingErrorHandler, UiThreadHandler uiThreadHandler) {
         super(clientDolphin, new BlindCommandBatcher());
         setUiThreadHandler(uiThreadHandler);
         this.servletUrl = Assert.requireNonNull(servletUrl, "servletUrl");
@@ -65,7 +66,7 @@ public class DolphinPlatformHttpClientConnector extends AbstractClientConnector 
         List<Command> result = new ArrayList<>();
         try {
             String content = codec.encode(commands);
-            HttpPost httpPost = new HttpPost(servletUrl);
+            HttpPost httpPost = new HttpPost(servletUrl.toString());
             StringEntity entity = new StringEntity(content, CHARSET);
             httpPost.setEntity(entity);
             if(clientId != null) {

--- a/platform/dolphin-platform-client/src/test/java/com/canoo/dolphin/client/impl/TestDolphinPlatformHttpClientConnector.java
+++ b/platform/dolphin-platform-client/src/test/java/com/canoo/dolphin/client/impl/TestDolphinPlatformHttpClientConnector.java
@@ -29,7 +29,7 @@ import java.net.URL;
 public class TestDolphinPlatformHttpClientConnector {
 
     @Test
-    public void testSimpleCall() throws MalformedURLException {
+    public void testSimpleCall() {
         HttpClient httpClient = new DefaultHttpClient() {
 
             @Override
@@ -38,8 +38,7 @@ public class TestDolphinPlatformHttpClientConnector {
             }
         };
 
-        final URL dummyURL = new URL("http://dummyURL");
-        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), httpClient, dummyURL, new ForwardableCallback<>(), new DummyUiThreadHandler());
+        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), httpClient, getDummyURL(), new ForwardableCallback<>(), new DummyUiThreadHandler());
 
         CreatePresentationModelCommand command = new CreatePresentationModelCommand();
         command.setPmId("p1");
@@ -51,7 +50,7 @@ public class TestDolphinPlatformHttpClientConnector {
     }
 
     @Test(expectedExceptions = DolphinRemotingException.class)
-    public void testBadResponse() throws MalformedURLException {
+    public void testBadResponse() {
         final CountDownLatch httpWasCalled = new CountDownLatch(1);
 
         HttpClient httpClient = new DefaultHttpClient() {
@@ -82,17 +81,22 @@ public class TestDolphinPlatformHttpClientConnector {
                 return (T) "[]";
             }
         };
-        final URL dummyURL = new URL("http://dummyURL");
-        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), httpClient, dummyURL, new ForwardableCallback<>(), new DummyUiThreadHandler());
+        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), httpClient, getDummyURL(), new ForwardableCallback<>(), new DummyUiThreadHandler());
 
         connector.transmit(Collections.singletonList(new Command()));
     }
 
     @Test(expectedExceptions = DolphinRemotingException.class)
-    public void testCallWithException() throws MalformedURLException {
-        final URL dummyURL = new URL("http://dummyURL");
-        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), new DefaultHttpClient(), dummyURL, new ForwardableCallback<>(), new DummyUiThreadHandler());
+    public void testCallWithException() {
+        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), new DefaultHttpClient(), getDummyURL(), new ForwardableCallback<>(), new DummyUiThreadHandler());
         connector.transmit(Collections.singletonList(new Command()));
     }
 
+    private URL getDummyURL() {
+        try {
+            return new URL("http://dummyURL");
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Exception occurred while creating URL", e);
+        }
+    }
 }

--- a/platform/dolphin-platform-client/src/test/java/com/canoo/dolphin/client/impl/TestDolphinPlatformHttpClientConnector.java
+++ b/platform/dolphin-platform-client/src/test/java/com/canoo/dolphin/client/impl/TestDolphinPlatformHttpClientConnector.java
@@ -23,11 +23,13 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 public class TestDolphinPlatformHttpClientConnector {
 
     @Test
-    public void testSimpleCall() {
+    public void testSimpleCall() throws MalformedURLException {
         HttpClient httpClient = new DefaultHttpClient() {
 
             @Override
@@ -35,7 +37,9 @@ public class TestDolphinPlatformHttpClientConnector {
                 return (T) "[{\"pmId\":\"p1\",\"clientSideOnly\":false,\"id\":\"CreatePresentationModel\",\"attributes\":[],\"pmType\":null,\"className\":\"org.opendolphin.core.comm.CreatePresentationModelCommand\"}]";
             }
         };
-        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), httpClient, "noUrl", new ForwardableCallback<>(), new DummyUiThreadHandler());
+
+        final URL dummyURL = new URL("http://dummyURL");
+        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), httpClient, dummyURL, new ForwardableCallback<>(), new DummyUiThreadHandler());
 
         CreatePresentationModelCommand command = new CreatePresentationModelCommand();
         command.setPmId("p1");
@@ -43,11 +47,11 @@ public class TestDolphinPlatformHttpClientConnector {
 
         Assert.assertEquals(result.size(), 1);
         Assert.assertTrue(result.get(0) instanceof CreatePresentationModelCommand);
-        Assert.assertEquals(((CreatePresentationModelCommand)result.get(0)).getPmId(), "p1");
+        Assert.assertEquals(((CreatePresentationModelCommand) result.get(0)).getPmId(), "p1");
     }
 
     @Test(expectedExceptions = DolphinRemotingException.class)
-    public void testBadResponse() {
+    public void testBadResponse() throws MalformedURLException {
         final CountDownLatch httpWasCalled = new CountDownLatch(1);
 
         HttpClient httpClient = new DefaultHttpClient() {
@@ -78,14 +82,16 @@ public class TestDolphinPlatformHttpClientConnector {
                 return (T) "[]";
             }
         };
-        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), httpClient, "noUrl", new ForwardableCallback<>(), new DummyUiThreadHandler());
+        final URL dummyURL = new URL("http://dummyURL");
+        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), httpClient, dummyURL, new ForwardableCallback<>(), new DummyUiThreadHandler());
 
         connector.transmit(Collections.singletonList(new Command()));
     }
 
     @Test(expectedExceptions = DolphinRemotingException.class)
-    public void testCallWithException() {
-        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), new DefaultHttpClient(), "noUrl", new ForwardableCallback<>(), new DummyUiThreadHandler());
+    public void testCallWithException() throws MalformedURLException {
+        final URL dummyURL = new URL("http://dummyURL");
+        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(new ClientDolphin(), new JsonCodec(), new DefaultHttpClient(), dummyURL, new ForwardableCallback<>(), new DummyUiThreadHandler());
         connector.transmit(Collections.singletonList(new Command()));
     }
 


### PR DESCRIPTION
Currently in java client server URL is passed as String. Changed the String type to URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/254)
<!-- Reviewable:end -->
