### PR TITLE
Add details to class cast error message while getting parameter type-…

### DIFF
--- a/platform/dolphin-platform-core/src/main/java/com/canoo/dolphin/impl/ReflectionHelper.java
+++ b/platform/dolphin-platform-core/src/main/java/com/canoo/dolphin/impl/ReflectionHelper.java
@@ -179,7 +179,7 @@ public class ReflectionHelper {
                 return (Class) pType.getActualTypeArguments()[0];
             }
         } catch (ClassCastException ex) {
-            LOG.warn("can not extract parameterized type!", ex);
+            LOG.warn("can not extract parameterized type for field: " +field.getName() + ", bean: "+ field.getDeclaringClass().getName(), ex);
         }
         return null;
     }


### PR DESCRIPTION
Intuitive message was missing in case of ClassCastException while calling getParameterType() in ReflectionHelper class. Added bean name and field name for which error occurred.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/335)
<!-- Reviewable:end -->
