### PR TITLE
Store command-id explicitly

### DIFF
--- a/remoting/dolphin-remoting-shared/src/main/java/org/opendolphin/core/comm/JsonCodec.java
+++ b/remoting/dolphin-remoting-shared/src/main/java/org/opendolphin/core/comm/JsonCodec.java
@@ -93,6 +93,7 @@ public class JsonCodec implements Codec {
             } else {
                 LOG.trace("Encoding command of type {}", command.getClass());
                 JsonElement element = GSON.toJsonTree(command);
+                element.getAsJsonObject().addProperty("id", command.getId());
                 element.getAsJsonObject().addProperty("className", command.getClass().getName());
                 ret.add(element);
             }


### PR DESCRIPTION
The GSON encoder seems to work on fields and not on properties like the Groovy encoder does. Therefore we have to set the id explicitly on each command. The id-property is used in the JS-client.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/337)
<!-- Reviewable:end -->
