### PR TITLE
Fix for dirty HTTP header

### DIFF
--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/DolphinPlatformHttpClientConnector.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/DolphinPlatformHttpClientConnector.java
@@ -97,7 +97,9 @@ public class DolphinPlatformHttpClientConnector extends AbstractClientConnector 
             conn.setRequestProperty(CONTENT_TYPE_HEADER, JSON_MIME_TYPE);
             conn.setRequestProperty(ACCEPT_HEADER, JSON_MIME_TYPE);
             conn.setRequestMethod(POST_METHOD);
-            conn.setRequestProperty(PlatformConstants.CLIENT_ID_HTTP_HEADER_NAME, clientId);
+            if(clientId != null) {
+                conn.setRequestProperty(PlatformConstants.CLIENT_ID_HTTP_HEADER_NAME, clientId);
+            }
             setRequestCookies(conn);
             String content = codec.encode(commands);
             OutputStream w = conn.getOutputStream();


### PR DESCRIPTION
This fixes a problem with empty HTTP headers that might be blocked by Apache

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/366)
<!-- Reviewable:end -->
