### PR TITLE
DolphinClient / DolphinServer deprecated & dependency between modelstore and connection

### DIFF
--- a/platform-extras/dolphin-platform-spring-controller-tester/src/main/java/com/canoo/dolphin/test/impl/DolphinPlatformSpringTestBootstrap.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/main/java/com/canoo/dolphin/test/impl/DolphinPlatformSpringTestBootstrap.java
@@ -111,7 +111,7 @@ public class DolphinPlatformSpringTestBootstrap {
             @Override
             public Void call() {
                 DolphinContextUtils.setContextForCurrentThread(dolphinContext);
-                clientDolphin.startPushListening(new StartLongPollCommand(), new InterruptLongPollCommand());
+                clientDolphin.getClientConnector().startPushListening(new StartLongPollCommand(), new InterruptLongPollCommand());
                 return null;
             }
 
@@ -133,7 +133,7 @@ public class DolphinPlatformSpringTestBootstrap {
         DolphinTestContext dolphinContext = new DolphinTestContext(ConfigurationFileLoader.loadConfiguration(), dolphinContextProviderMock, containerManager, controllerRepository, config);
         dolphinContextProviderMock.setCurrentContext(dolphinContext);
 
-        DolphinTestClientConnector inMemoryClientConnector = new DolphinTestClientConnector(config.getClientDolphin(), config.getClientExecutor(), dolphinContext);
+        DolphinTestClientConnector inMemoryClientConnector = new DolphinTestClientConnector(config.getClientDolphin().getModelStore(), config.getClientExecutor(), dolphinContext);
 
         inMemoryClientConnector.setStrictMode(false);
         config.getClientDolphin().setClientConnector(inMemoryClientConnector);
@@ -145,8 +145,8 @@ public class DolphinPlatformSpringTestBootstrap {
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
     public TestInMemoryConfiguration createInMemoryConfig() throws ExecutionException, InterruptedException {
         TestInMemoryConfiguration config = new TestInMemoryConfiguration();
-        config.getServerDolphin().registerDefaultActions();
-        ServerModelStore store = config.getServerDolphin().getServerModelStore();
+        config.getServerDolphin().getServerConnector().registerDefaultActions();
+        ServerModelStore store = config.getServerDolphin().getModelStore();
         try {
             ReflectionHelper.setPrivileged(ServerModelStore.class.getDeclaredField("currentResponse"), store, new ArrayList<>());
         } catch (NoSuchFieldException e) {

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/main/java/com/canoo/dolphin/test/impl/DolphinTestClientConnector.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/main/java/com/canoo/dolphin/test/impl/DolphinTestClientConnector.java
@@ -18,7 +18,7 @@ package com.canoo.dolphin.test.impl;
 import com.canoo.dolphin.impl.commands.StartLongPollCommand;
 import com.canoo.dolphin.server.context.DolphinContext;
 import com.canoo.dolphin.util.Assert;
-import org.opendolphin.core.client.ClientDolphin;
+import org.opendolphin.core.client.ClientModelStore;
 import org.opendolphin.core.client.comm.*;
 import org.opendolphin.core.comm.Command;
 
@@ -34,8 +34,8 @@ public class DolphinTestClientConnector extends AbstractClientConnector {
 
     private final Executor uiExecutor;
 
-    public DolphinTestClientConnector(ClientDolphin clientDolphin, Executor uiExecutor, DolphinContext dolphinContext) {
-        super(clientDolphin, uiExecutor, new CommandBatcher(), new SimpleExceptionHandler(uiExecutor), Executors.newCachedThreadPool());
+    public DolphinTestClientConnector(ClientModelStore clientModelStore, Executor uiExecutor, DolphinContext dolphinContext) {
+        super(clientModelStore, uiExecutor, new CommandBatcher(), new SimpleExceptionHandler(uiExecutor), Executors.newCachedThreadPool());
         this.dolphinContext = Assert.requireNonNull(dolphinContext, "dolphinContext");
         this.uiExecutor = Assert.requireNonNull(uiExecutor, "uiExecutor");
     }

--- a/platform-extras/dolphin-platform-spring-controller-tester/src/main/java/com/canoo/dolphin/test/impl/TestInMemoryConfiguration.java
+++ b/platform-extras/dolphin-platform-spring-controller-tester/src/main/java/com/canoo/dolphin/test/impl/TestInMemoryConfiguration.java
@@ -17,8 +17,12 @@ package com.canoo.dolphin.test.impl;
 
 import org.opendolphin.core.client.ClientDolphin;
 import org.opendolphin.core.client.ClientModelStore;
+import org.opendolphin.core.client.DefaultModelSynchronizer;
+import org.opendolphin.core.client.ModelSynchronizer;
+import org.opendolphin.core.client.comm.ClientConnector;
 import org.opendolphin.core.server.DefaultServerDolphin;
 import org.opendolphin.core.server.ServerDolphinFactory;
+import org.opendolphin.util.Provider;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -32,7 +36,13 @@ public class TestInMemoryConfiguration {
     private final ExecutorService clientExecutor = Executors.newSingleThreadExecutor();
 
     public TestInMemoryConfiguration() {
-        clientDolphin.setClientModelStore(new ClientModelStore(clientDolphin));
+        ModelSynchronizer defaultModelSynchronizer = new DefaultModelSynchronizer(new Provider<ClientConnector>() {
+            @Override
+            public ClientConnector get() {
+                return clientDolphin.getClientConnector();
+            }
+        });
+        clientDolphin.setClientModelStore(new ClientModelStore(defaultModelSynchronizer));
     }
 
     public ExecutorService getClientExecutor() {

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/ClientContextImpl.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/ClientContextImpl.java
@@ -106,7 +106,7 @@ public class ClientContextImpl implements ClientContext {
     public synchronized CompletableFuture<Void> disconnect() {
         checkForInitializedState();
         state = State.DESTROYING;
-        clientDolphin.stopPushListening();
+        clientDolphin.getClientConnector().stopPushListening();
         final CompletableFuture<Void> result = new CompletableFuture<>();
 
         Executors.newSingleThreadExecutor().execute(new Runnable() {

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/ClientPresentationModelBuilder.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/ClientPresentationModelBuilder.java
@@ -54,7 +54,7 @@ public class ClientPresentationModelBuilder extends AbstractPresentationModelBui
 
     @Override
     public ClientPresentationModel create() {
-        return dolphin.presentationModel(id, type, attributes.toArray(new ClientAttribute[attributes.size()]));
+        return dolphin.getModelStore().createModel(id, type, attributes.toArray(new ClientAttribute[attributes.size()]));
     }
 
 }

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/ControllerProxyImpl.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/ControllerProxyImpl.java
@@ -66,7 +66,7 @@ public class ControllerProxyImpl<T> implements ControllerProxy<T> {
 
 
         final CompletableFuture<Void> result = new CompletableFuture<>();
-        dolphin.send(new CallActionCommand(), new OnFinishedHandler(){
+        dolphin.getClientConnector().send(new CallActionCommand(), new OnFinishedHandler(){
             @Override
             public void onFinished() {
                 if (bean.isError()) {
@@ -92,7 +92,7 @@ public class ControllerProxyImpl<T> implements ControllerProxy<T> {
 
         final CompletableFuture<Void> ret = new CompletableFuture<>();
 
-        dolphin.send(new DestroyControllerCommand(), new OnFinishedHandler() {
+        dolphin.getClientConnector().send(new DestroyControllerCommand(), new OnFinishedHandler() {
             @Override
             public void onFinished() {
                 model = null;

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/DolphinCommandHandler.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/DolphinCommandHandler.java
@@ -33,7 +33,7 @@ public class DolphinCommandHandler {
     public CompletableFuture<Void> invokeDolphinCommand(Command command) {
         Assert.requireNonNull(command, "command");
         final CompletableFuture<Void> result = new CompletableFuture<>();
-        clientDolphin.send(command, new OnFinishedHandler() {
+        clientDolphin.getClientConnector().send(command, new OnFinishedHandler() {
             @Override
             public void onFinished() {
                 result.complete(null);

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/DolphinPlatformHttpClientConnector.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dolphin/client/impl/DolphinPlatformHttpClientConnector.java
@@ -76,7 +76,7 @@ public class DolphinPlatformHttpClientConnector extends AbstractClientConnector 
     private String clientId;
 
     public DolphinPlatformHttpClientConnector(ClientConfiguration configuration, ClientDolphin clientDolphin, Codec codec, ForwardableCallback<DolphinRemotingException> remotingErrorHandler, ExceptionHandler onException) {
-        super(clientDolphin, Assert.requireNonNull(configuration, "configuration").getUiExecutor(), new BlindCommandBatcher(), onException, configuration.getBackgroundExecutor());
+        super(clientDolphin.getModelStore(), Assert.requireNonNull(configuration, "configuration").getUiExecutor(), new BlindCommandBatcher(), onException, configuration.getBackgroundExecutor());
         setStrictMode(false);
 
         this.servletUrl = configuration.getServerEndpoint();

--- a/platform/dolphin-platform-client/src/test/java/com/canoo/dolphin/client/TestObservableListSync.java
+++ b/platform/dolphin-platform-client/src/test/java/com/canoo/dolphin/client/TestObservableListSync.java
@@ -55,7 +55,7 @@ public class TestObservableListSync extends AbstractDolphinBasedTest {
         }
 
         public PresentationModel create() {
-            return dolphin.presentationModel(UUID.randomUUID().toString(), type, attributes.toArray(new ClientAttribute[attributes.size()]));
+            return dolphin.getModelStore().createModel(UUID.randomUUID().toString(), type, attributes.toArray(new ClientAttribute[attributes.size()]));
         }
 
     }
@@ -1751,7 +1751,7 @@ public class TestObservableListSync extends AbstractDolphinBasedTest {
     private void deleteAllPresentationModelsOfType(ClientDolphin dolphin, String listSplice) {
         List<ClientPresentationModel> toDelete = new ArrayList<>(dolphin.getModelStore().findAllPresentationModelsByType(listSplice));
         for(ClientPresentationModel model : toDelete) {
-            dolphin.delete(model);
+            dolphin.getModelStore().delete(model);
         }
     }
 

--- a/platform/dolphin-platform-client/src/test/java/com/canoo/dolphin/client/impl/TestDolphinCommandHandler.java
+++ b/platform/dolphin-platform-client/src/test/java/com/canoo/dolphin/client/impl/TestDolphinCommandHandler.java
@@ -42,8 +42,8 @@ public class TestDolphinCommandHandler extends AbstractDolphinBasedTest {
         final ClientDolphin clientDolphin = configuration.getClientDolphin();
         final DolphinCommandHandler dolphinCommandHandler = new DolphinCommandHandler(clientDolphin);
         final String modelId = UUID.randomUUID().toString();
-        clientDolphin.presentationModel(modelId, new ClientAttribute("myAttribute", "UNKNOWN"));
-        serverDolphin.register(new DolphinServerAction() {
+        clientDolphin.getModelStore().createModel(modelId, null, new ClientAttribute("myAttribute", "UNKNOWN"));
+        serverDolphin.getServerConnector().register(new DolphinServerAction() {
             @Override
             public void registerIn(ActionRegistry registry) {
                 registry.register(TestChangeCommand.class, new CommandHandler() {

--- a/platform/dolphin-platform-client/src/test/java/com/canoo/dolphin/client/impl/TestDolphinPlatformHttpClientConnector.java
+++ b/platform/dolphin-platform-client/src/test/java/com/canoo/dolphin/client/impl/TestDolphinPlatformHttpClientConnector.java
@@ -21,10 +21,14 @@ import com.canoo.dolphin.client.HttpURLConnectionFactory;
 import com.canoo.dolphin.impl.commands.CreateContextCommand;
 import com.canoo.dolphin.util.DolphinRemotingException;
 import org.opendolphin.core.client.ClientDolphin;
+import org.opendolphin.core.client.ClientModelStore;
+import org.opendolphin.core.client.DefaultModelSynchronizer;
+import org.opendolphin.core.client.comm.ClientConnector;
 import org.opendolphin.core.client.comm.SimpleExceptionHandler;
 import org.opendolphin.core.comm.Command;
 import org.opendolphin.core.comm.CreatePresentationModelCommand;
 import org.opendolphin.core.comm.JsonCodec;
+import org.opendolphin.util.Provider;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -78,7 +82,14 @@ public class TestDolphinPlatformHttpClientConnector {
             }
         });
 
-        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(clientConfiguration, new ClientDolphin(), new JsonCodec(), new ForwardableCallback<DolphinRemotingException>(), new SimpleExceptionHandler(clientConfiguration.getUiExecutor()));
+        ClientDolphin clientDolphin = new ClientDolphin();
+        clientDolphin.setClientModelStore(new ClientModelStore(new DefaultModelSynchronizer(new Provider<ClientConnector>() {
+            @Override
+            public ClientConnector get() {
+                return null;
+            }
+        })));
+        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(clientConfiguration, clientDolphin, new JsonCodec(), new ForwardableCallback<DolphinRemotingException>(), new SimpleExceptionHandler(clientConfiguration.getUiExecutor()));
 
         CreatePresentationModelCommand command = new CreatePresentationModelCommand();
         command.setPmId("p1");
@@ -122,8 +133,14 @@ public class TestDolphinPlatformHttpClientConnector {
             }
         });
 
-
-        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(clientConfiguration, new ClientDolphin(), new JsonCodec(), new ForwardableCallback<DolphinRemotingException>(), new SimpleExceptionHandler(clientConfiguration.getUiExecutor()));
+        ClientDolphin clientDolphin = new ClientDolphin();
+        clientDolphin.setClientModelStore(new ClientModelStore(new DefaultModelSynchronizer(new Provider<ClientConnector>() {
+            @Override
+            public ClientConnector get() {
+                return null;
+            }
+        })));
+        DolphinPlatformHttpClientConnector connector = new DolphinPlatformHttpClientConnector(clientConfiguration, clientDolphin, new JsonCodec(), new ForwardableCallback<DolphinRemotingException>(), new SimpleExceptionHandler(clientConfiguration.getUiExecutor()));
 
         List<Command> commands = new ArrayList<>();
         commands.add(new CreateContextCommand());

--- a/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/context/DefaultOpenDolphinFactory.java
+++ b/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/context/DefaultOpenDolphinFactory.java
@@ -33,7 +33,7 @@ public class DefaultOpenDolphinFactory implements OpenDolphinFactory {
         serverConnector.setCodec(new OptimizedJsonCodec());
         serverConnector.setServerModelStore(modelStore);
         final DefaultServerDolphin dolphin = new DefaultServerDolphin(modelStore, serverConnector);
-        dolphin.registerDefaultActions();
+        dolphin.getServerConnector().registerDefaultActions();
         return dolphin;
     }
 }

--- a/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/context/DolphinContext.java
+++ b/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/context/DolphinContext.java
@@ -161,7 +161,7 @@ public class DolphinContext {
     }
 
     private void registerDolphinPlatformDefaultCommands() {
-        dolphin.register(new DolphinServerAction() {
+        dolphin.getServerConnector().register(new DolphinServerAction() {
             @Override
             public void registerIn(ActionRegistry registry) {
 

--- a/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/impl/ServerPresentationModelBuilder.java
+++ b/platform/dolphin-platform-server/src/main/java/com/canoo/dolphin/server/impl/ServerPresentationModelBuilder.java
@@ -57,7 +57,7 @@ public class ServerPresentationModelBuilder extends AbstractPresentationModelBui
 
     @Override
     public ServerPresentationModel create() {
-        return dolphin.presentationModel(id, type, new DTO(slots));
+        return dolphin.getModelStore().presentationModel(id, type, new DTO(slots));
     }
 
 }

--- a/platform/dolphin-platform-server/src/test/java/com/canoo/dolphin/server/TestObservableListSync.java
+++ b/platform/dolphin-platform-server/src/test/java/com/canoo/dolphin/server/TestObservableListSync.java
@@ -58,7 +58,7 @@ public class TestObservableListSync extends AbstractDolphinBasedTest {
         }
 
         public PresentationModel create() {
-            return dolphin.presentationModel(UUID.randomUUID().toString(), type, new DTO(slots));
+            return dolphin.getModelStore().presentationModel(UUID.randomUUID().toString(), type, new DTO(slots));
         }
 
     }

--- a/platform/dolphin-platform-server/src/test/java/com/canoo/dolphin/server/context/DefaultOpenDolphinFactoryTest.java
+++ b/platform/dolphin-platform-server/src/test/java/com/canoo/dolphin/server/context/DefaultOpenDolphinFactoryTest.java
@@ -33,7 +33,7 @@ public class DefaultOpenDolphinFactoryTest {
         assertNotNull(serverDolphin);
         assertNotNull(serverDolphin.getModelStore());
         assertNotNull(serverDolphin.getServerConnector());
-        assertNotNull(serverDolphin.getServerModelStore());
+        assertNotNull(serverDolphin.getModelStore());
         assertNotNull(serverDolphin.getServerConnector().getCodec());
         assertEquals(OptimizedJsonCodec.class, serverDolphin.getServerConnector().getCodec().getClass());
 

--- a/platform/dolphin-platform-server/src/test/java/com/canoo/dolphin/server/util/AbstractDolphinBasedTest.java
+++ b/platform/dolphin-platform-server/src/test/java/com/canoo/dolphin/server/util/AbstractDolphinBasedTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractDolphinBasedTest {
 
     protected ServerDolphin createServerDolphin() {
         DefaultInMemoryConfig config = new DefaultInMemoryConfig(DirectExecutor.getInstance());
-        config.getServerDolphin().registerDefaultActions();
+        config.getServerDolphin().getServerConnector().registerDefaultActions();
 
         ServerModelStore store = config.getServerDolphin().getModelStore();
         List<Command> commands = new ArrayList<>();

--- a/remoting/dolphin-remoting-client/src/main/java/org/opendolphin/core/client/ClientDolphin.java
+++ b/remoting/dolphin-remoting-client/src/main/java/org/opendolphin/core/client/ClientDolphin.java
@@ -16,17 +16,9 @@
 package org.opendolphin.core.client;
 
 import org.opendolphin.core.Dolphin;
-import org.opendolphin.core.ModelStore;
 import org.opendolphin.core.client.comm.ClientConnector;
 import org.opendolphin.core.client.comm.OnFinishedHandler;
-import org.opendolphin.core.comm.Command;
 import org.opendolphin.core.comm.EmptyNotification;
-import org.opendolphin.core.comm.SignalCommand;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 /**
  * The main Dolphin facade on the client side.
@@ -34,6 +26,7 @@ import java.util.Map;
  * Collaborates with client model store and client connector.
  * Threading model: confined to the UI handling thread.
  */
+@Deprecated
 public class ClientDolphin implements Dolphin<ClientAttribute, ClientPresentationModel> {
 
     private ClientModelStore clientModelStore;
@@ -41,62 +34,12 @@ public class ClientDolphin implements Dolphin<ClientAttribute, ClientPresentatio
     private ClientConnector clientConnector;
 
     @Override
-    public ModelStore<ClientAttribute, ClientPresentationModel> getModelStore() {
+    public ClientModelStore getModelStore() {
         return clientModelStore;
     }
 
-    /**
-     * Convenience method for a creating a ClientPresentationModel with initial null values for the attributes
-     */
-    @Deprecated
-    public ClientPresentationModel presentationModel(String id, List<String> attributeNames) {
-        List<ClientAttribute> attributes = new ArrayList<ClientAttribute>();
-        for (String name : attributeNames) {
-            attributes.add(new ClientAttribute(name, null));
-        }
-
-        ClientPresentationModel result = new ClientPresentationModel(id, attributes);
-        clientModelStore.add(result);
-        return result;
-    }
-
-    @Deprecated
-    public ClientPresentationModel presentationModel(Map<String, Object> attributeNamesAndValues, String id) {
-        return presentationModel(attributeNamesAndValues, id, null);
-    }
-
-    /**
-     * groovy-friendly convenience method for a typical case of creating a ClientPresentationModel with initial values
-     */
-    @Deprecated
-    public ClientPresentationModel presentationModel(Map<String, Object> attributeNamesAndValues, String id, String presentationModelType) {
-        List<ClientAttribute> attributes = new ArrayList<ClientAttribute>();
-        for (Map.Entry<String, Object> entry : attributeNamesAndValues.entrySet()) {
-            ((ArrayList<ClientAttribute>) attributes).add(new ClientAttribute(entry.getKey(), entry.getValue()));
-        }
-
-        ClientPresentationModel result = new ClientPresentationModel(id, attributes);
-        result.setPresentationModelType(presentationModelType);
-        clientModelStore.add(result);
-        return result;
-    }
-
-    public ClientPresentationModel presentationModel(String id, ClientAttribute... attributes) {
-        return presentationModel(id, null, attributes);
-    }
-
-    /**
-     * both groovy- and java-friendly full-control constructor
-     */
-    public ClientPresentationModel presentationModel(String id, String presentationModelType, ClientAttribute... attributes) {
-        ClientPresentationModel result = new ClientPresentationModel(id, Arrays.asList(attributes));
-        result.setPresentationModelType(presentationModelType);
-        clientModelStore.add(result);
-        return result;
-    }
-
-    public void send(Command command, OnFinishedHandler onFinished) {
-        clientConnector.send(command, onFinished);
+    public ClientConnector getClientConnector() {
+        return clientConnector;
     }
 
     /**
@@ -111,39 +54,6 @@ public class ClientDolphin implements Dolphin<ClientAttribute, ClientPresentatio
             }
 
         });
-    }
-
-    /**
-     * Removes the modelToDelete from the client model store,
-     * detaches all model store listeners,
-     * and notifies the server if successful
-     */
-    public void delete(ClientPresentationModel modelToDelete) {
-        clientModelStore.delete(modelToDelete);
-    }
-
-    /**
-     * @deprecated Push should be active by default
-     */
-    @Deprecated
-    public void startPushListening(final Command startLongPollCommand, final SignalCommand interruptLongPollCommand) {
-        clientConnector.startPushListening(startLongPollCommand, interruptLongPollCommand);
-    }
-
-    /**
-     * @deprecated Push should be active by default
-     */
-    @Deprecated
-    public void stopPushListening() {
-        clientConnector.stopPushListening();
-    }
-
-    public ClientModelStore getClientModelStore() {
-        return clientModelStore;
-    }
-
-    public ClientConnector getClientConnector() {
-        return clientConnector;
     }
 
     /**

--- a/remoting/dolphin-remoting-client/src/main/java/org/opendolphin/core/client/DefaultModelSynchronizer.java
+++ b/remoting/dolphin-remoting-client/src/main/java/org/opendolphin/core/client/DefaultModelSynchronizer.java
@@ -1,0 +1,49 @@
+package org.opendolphin.core.client;
+
+import org.opendolphin.core.Attribute;
+import org.opendolphin.core.client.comm.ClientConnector;
+import org.opendolphin.core.comm.*;
+import org.opendolphin.util.Provider;
+
+import java.beans.PropertyChangeEvent;
+
+public class DefaultModelSynchronizer implements ModelSynchronizer {
+
+    private final Provider<ClientConnector> connectionProvider;
+
+    public DefaultModelSynchronizer(Provider<ClientConnector> connectionProvider) {
+        this.connectionProvider = connectionProvider;
+    }
+
+    @Override
+    public void onAdded(final ClientPresentationModel model) {
+        final Command command = CreatePresentationModelCommand.makeFrom(model);
+        send(command);
+    }
+
+    @Override
+    public void onDeleted(final ClientPresentationModel model) {
+        final Command command = new DeletedPresentationModelNotification(model.getId());
+        send(command);
+    }
+
+    @Override
+    public void onPropertyChanged(final PropertyChangeEvent evt) {
+        final Command command = new ValueChangedCommand(((Attribute) evt.getSource()).getId(), evt.getOldValue(), evt.getNewValue());
+        send(command);
+    }
+
+    @Override
+    public void onMetadataChanged(final PropertyChangeEvent evt) {
+        final Command command = new ChangeAttributeMetadataCommand(((Attribute) evt.getSource()).getId(), evt.getPropertyName(), evt.getNewValue());
+        send(command);
+    }
+
+    private void send(Command command) {
+        ClientConnector clientConnector = connectionProvider.get();
+        if(clientConnector == null) {
+            throw new IllegalStateException("No connection defined!");
+        }
+        clientConnector.send(command);
+    }
+}

--- a/remoting/dolphin-remoting-client/src/main/java/org/opendolphin/core/client/ModelSynchronizer.java
+++ b/remoting/dolphin-remoting-client/src/main/java/org/opendolphin/core/client/ModelSynchronizer.java
@@ -1,0 +1,14 @@
+package org.opendolphin.core.client;
+
+import java.beans.PropertyChangeEvent;
+
+public interface ModelSynchronizer {
+
+    void onAdded(ClientPresentationModel model);
+
+    void onDeleted(ClientPresentationModel model);
+
+    void onPropertyChanged(PropertyChangeEvent evt);
+
+    void onMetadataChanged(PropertyChangeEvent evt);
+}

--- a/remoting/dolphin-remoting-client/src/main/java/org/opendolphin/core/client/comm/AbstractClientConnector.java
+++ b/remoting/dolphin-remoting-client/src/main/java/org/opendolphin/core/client/comm/AbstractClientConnector.java
@@ -15,7 +15,7 @@
  */
 package org.opendolphin.core.client.comm;
 
-import org.opendolphin.core.client.ClientDolphin;
+import org.opendolphin.core.client.ClientModelStore;
 import org.opendolphin.core.comm.Command;
 import org.opendolphin.core.comm.SignalCommand;
 
@@ -60,20 +60,18 @@ public abstract class AbstractClientConnector implements ClientConnector {
      */
     protected final AtomicBoolean releaseNeeded = new AtomicBoolean(false);
 
-    protected AbstractClientConnector(final ClientDolphin clientDolphin, final Executor uiExecutor, final ICommandBatcher commandBatcher, ExceptionHandler onException, Executor backgroundExecutor) {
+    protected AbstractClientConnector(final ClientModelStore clientModelStore, final Executor uiExecutor, final ICommandBatcher commandBatcher, ExceptionHandler onException, Executor backgroundExecutor) {
         this.uiExecutor = Objects.requireNonNull(uiExecutor);
         this.commandBatcher = Objects.requireNonNull(commandBatcher);
         this.onException = Objects.requireNonNull(onException);
         this.backgroundExecutor = Objects.requireNonNull(backgroundExecutor);
-        this.responseHandler = new ClientResponseHandler(Objects.requireNonNull(clientDolphin));
-
+        this.responseHandler = new ClientResponseHandler(clientModelStore);
         backgroundExecutor.execute(new Runnable() {
             @Override
             public void run() {
                 commandProcessing();
             }
         });
-
     }
 
     protected void commandProcessing() {

--- a/remoting/dolphin-remoting-client/src/main/java/org/opendolphin/core/client/comm/ClientConnector.java
+++ b/remoting/dolphin-remoting-client/src/main/java/org/opendolphin/core/client/comm/ClientConnector.java
@@ -18,6 +18,10 @@ package org.opendolphin.core.client.comm;
 import org.opendolphin.core.comm.Command;
 import org.opendolphin.core.comm.SignalCommand;
 
+/**
+ * @Deprecated since the only direct implementation is {@link AbstractClientConnector}
+ */
+@Deprecated
 public interface ClientConnector {
 
     void send(Command command, OnFinishedHandler callback, HandlerType handlerType);

--- a/remoting/dolphin-remoting-combined/src/main/java/core/client/comm/InMemoryClientConnector.java
+++ b/remoting/dolphin-remoting-combined/src/main/java/core/client/comm/InMemoryClientConnector.java
@@ -15,7 +15,7 @@
  */
 package core.client.comm;
 
-import org.opendolphin.core.client.ClientDolphin;
+import org.opendolphin.core.client.ClientModelStore;
 import org.opendolphin.core.client.comm.AbstractClientConnector;
 import org.opendolphin.core.client.comm.ICommandBatcher;
 import org.opendolphin.core.client.comm.SimpleExceptionHandler;
@@ -39,12 +39,9 @@ public class InMemoryClientConnector extends AbstractClientConnector {
 
     private long sleepMillis = 0;
 
-    private final Executor uiExecutor;
-
-    public InMemoryClientConnector(ClientDolphin clientDolphin, ServerConnector serverConnector, ICommandBatcher commandBatcher, Executor uiExecutor) {
-        super(clientDolphin, uiExecutor, commandBatcher, new SimpleExceptionHandler(uiExecutor), Executors.newCachedThreadPool());
-        this.uiExecutor = Objects.requireNonNull(uiExecutor);
-        this.serverConnector = serverConnector;
+    public InMemoryClientConnector(final ClientModelStore clientModelStore, final ServerConnector serverConnector, final ICommandBatcher commandBatcher, final Executor uiExecutor) {
+        super(clientModelStore, uiExecutor, commandBatcher, new SimpleExceptionHandler(uiExecutor), Executors.newCachedThreadPool());
+        this.serverConnector = Objects.requireNonNull(serverConnector);
     }
 
     @Override
@@ -54,26 +51,18 @@ public class InMemoryClientConnector extends AbstractClientConnector {
             LOGGER.warn("no server connector wired for in-memory connector");
             return Collections.EMPTY_LIST;
         }
-
-
         if (sleepMillis > 0) {
             try {
                 Thread.sleep(sleepMillis);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-
-
         }
-
-
         List<Command> result = new LinkedList<Command>();
         for (Command command : commands) {
             LOGGER.trace("processing {}", command);
-            ((LinkedList<Command>) result).addAll(serverConnector.receive(command));// there is no need for encoding since we are in-memory
+            result.addAll(serverConnector.receive(command));// there is no need for encoding since we are in-memory
         }
-
-
         return result;
     }
 

--- a/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/client/comm/InMemoryClientConnectorTests.groovy
+++ b/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/client/comm/InMemoryClientConnectorTests.groovy
@@ -17,14 +17,35 @@ package org.opendolphin.core.client.comm
 
 import core.client.comm.InMemoryClientConnector
 import org.opendolphin.core.client.ClientDolphin
+import org.opendolphin.core.client.ClientModelStore
+import org.opendolphin.core.client.DefaultModelSynchronizer
+import org.opendolphin.core.client.ModelSynchronizer
 import org.opendolphin.core.comm.EmptyNotification
 import org.opendolphin.core.server.ServerConnector
 import org.opendolphin.util.DirectExecutor
+import org.opendolphin.util.Provider
 
 class InMemoryClientConnectorTests extends GroovyTestCase {
 
     void testCallConnector_NoServerConnectorWired() {
-        InMemoryClientConnector connector = new InMemoryClientConnector(new ClientDolphin(), null, new CommandBatcher(), DirectExecutor.getInstance())
+
+        def serverConnector = [receive: { cmd ->
+            return []
+        }] as ServerConnector
+
+        ClientDolphin clientDolphin = new ClientDolphin();
+        ModelSynchronizer defaultModelSynchronizer = new DefaultModelSynchronizer(new Provider<ClientConnector>() {
+            @Override
+            ClientConnector get() {
+                return clientDolphin.getClientConnector();
+            }
+        });
+        ClientModelStore modelStore = new ClientModelStore(defaultModelSynchronizer);
+        AbstractClientConnector connector = new InMemoryClientConnector(modelStore, serverConnector, new CommandBatcher(), DirectExecutor.getInstance());
+
+        clientDolphin.setClientConnector(connector);
+        clientDolphin.setClientModelStore(modelStore);
+
         assert [] == connector.transmit([new EmptyNotification()])
     }
 
@@ -34,7 +55,20 @@ class InMemoryClientConnectorTests extends GroovyTestCase {
             serverCalled = true
             return []
         }] as ServerConnector
-        InMemoryClientConnector connector = new InMemoryClientConnector(new ClientDolphin(), serverConnector, new CommandBatcher(), DirectExecutor.getInstance())
+
+        ClientDolphin clientDolphin = new ClientDolphin();
+        ModelSynchronizer defaultModelSynchronizer = new DefaultModelSynchronizer(new Provider<ClientConnector>() {
+            @Override
+            ClientConnector get() {
+                return clientDolphin.getClientConnector();
+            }
+        });
+        ClientModelStore modelStore = new ClientModelStore(defaultModelSynchronizer);
+        AbstractClientConnector connector = new InMemoryClientConnector(modelStore, serverConnector, new CommandBatcher(), DirectExecutor.getInstance());
+
+        clientDolphin.setClientConnector(connector);
+        clientDolphin.setClientModelStore(modelStore);
+
         def command = new EmptyNotification()
         connector.transmit([command])
         assert serverCalled
@@ -46,7 +80,20 @@ class InMemoryClientConnectorTests extends GroovyTestCase {
             serverCalled = true
             return []
         }] as ServerConnector
-        InMemoryClientConnector connector = new InMemoryClientConnector(new ClientDolphin(), serverConnector, new CommandBatcher(), DirectExecutor.getInstance())
+
+        ClientDolphin clientDolphin = new ClientDolphin();
+        ModelSynchronizer defaultModelSynchronizer = new DefaultModelSynchronizer(new Provider<ClientConnector>() {
+            @Override
+            ClientConnector get() {
+                return clientDolphin.getClientConnector();
+            }
+        });
+        ClientModelStore modelStore = new ClientModelStore(defaultModelSynchronizer);
+        AbstractClientConnector connector = new InMemoryClientConnector(modelStore, serverConnector, new CommandBatcher(), DirectExecutor.getInstance());
+
+        clientDolphin.setClientConnector(connector);
+        clientDolphin.setClientModelStore(modelStore);
+
         connector.sleepMillis = 10
         def command = new EmptyNotification()
         connector.transmit([command])

--- a/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/client/comm/SynchronousInMemoryClientConnector.java
+++ b/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/client/comm/SynchronousInMemoryClientConnector.java
@@ -16,7 +16,7 @@
 package org.opendolphin.core.client.comm;
 
 import core.client.comm.InMemoryClientConnector;
-import org.opendolphin.core.client.ClientDolphin;
+import org.opendolphin.core.client.ClientModelStore;
 import org.opendolphin.core.comm.Command;
 import org.opendolphin.core.server.ServerConnector;
 
@@ -33,8 +33,8 @@ import java.util.concurrent.Executor;
  */
 public class SynchronousInMemoryClientConnector extends InMemoryClientConnector {
 
-    public SynchronousInMemoryClientConnector(ClientDolphin clientDolphin, ServerConnector serverConnector) {
-        super(clientDolphin, serverConnector, new CommandBatcher(), new Executor() {
+    public SynchronousInMemoryClientConnector(ClientModelStore clientModelStore, ServerConnector serverConnector) {
+        super(clientModelStore, serverConnector, new CommandBatcher(), new Executor() {
             @Override
             public void execute(Runnable command) {
                 throw new RuntimeException("should not reach here!");

--- a/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/comm/ClientConnectorPushTests.groovy
+++ b/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/comm/ClientConnectorPushTests.groovy
@@ -44,14 +44,14 @@ class ClientConnectorPushTests extends Specification {
     protected void cleanup() {
         clientDolphin.sync { app.assertionsDone() }
         assert app.done.await(4, TimeUnit.SECONDS) // max waiting time for async operations to have finished
-        clientDolphin.stopPushListening()
+        clientDolphin.getClientConnector().stopPushListening()
     }
 
     void "listening can be started and stopped"() {
         when:
-        clientDolphin.startPushListening(new PollCommand(), new SignalCommand("INTERRUPT"))
+        clientDolphin.getClientConnector().startPushListening(new PollCommand(), new SignalCommand("INTERRUPT"))
         then:
-        clientDolphin.stopPushListening()
+        clientDolphin.getClientConnector().stopPushListening()
     }
 
     @Ignore
@@ -62,7 +62,7 @@ class ClientConnectorPushTests extends Specification {
             pushWasCalled.countDown()
         }
         when:
-        clientDolphin.startPushListening(new PollCommand("POLL"), new SignalCommand("INTERRUPT"))
+        clientDolphin.getClientConnector().startPushListening(new PollCommand("POLL"), new SignalCommand("INTERRUPT"))
         then:
         pushWasCalled.await(1, TimeUnit.SECONDS)
     }

--- a/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/comm/CommunicationTests.groovy
+++ b/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/comm/CommunicationTests.groovy
@@ -49,7 +49,7 @@ class CommunicationTests extends GroovyTestCase {
 		config = new TestInMemoryConfig()
         serverConnector  = config.serverDolphin.serverConnector
         clientConnector  = config.clientDolphin.clientConnector
-        clientModelStore = config.clientDolphin.clientModelStore
+        clientModelStore = config.clientDolphin.getModelStore()
         clientDolphin    = config.clientDolphin
 	}
 

--- a/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/comm/DeletePresentationModelTests.groovy
+++ b/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/comm/DeletePresentationModelTests.groovy
@@ -15,6 +15,7 @@
  */
 package org.opendolphin.core.comm
 
+import org.opendolphin.core.client.ClientAttribute
 import org.opendolphin.core.client.ClientDolphin
 import org.opendolphin.core.client.comm.OnFinishedHandler
 import org.opendolphin.core.server.DefaultServerDolphin
@@ -48,7 +49,7 @@ class DeletePresentationModelTests extends GroovyTestCase {
     }
 
     public <T extends Command> void registerAction(ServerDolphin serverDolphin, Class<T> commandClass, CommandHandler<T> handler) {
-        serverDolphin.register(new DolphinServerAction() {
+        serverDolphin.getServerConnector().register(new DolphinServerAction() {
 
             @Override
             void registerIn(ActionRegistry registry) {
@@ -60,7 +61,7 @@ class DeletePresentationModelTests extends GroovyTestCase {
     void testCreateAndDeletePresentationModel() {
         // create the pm
         String modelId = 'modelId'
-        def model = clientDolphin.presentationModel(modelId, someAttribute:"someValue")
+        def model = clientDolphin.getModelStore().createModel(modelId, null, new ClientAttribute("someAttribute", "someValue"));
         // sanity check: we have a least the client model store listening to changes of someAttribute
         assert model.getAttribute("someAttribute").propertyChangeListeners
         // the model is in the client model store
@@ -71,7 +72,7 @@ class DeletePresentationModelTests extends GroovyTestCase {
             assert serverDolphin.getModelStore().findPresentationModelById(modelId)
         }
         // when we now delete the pm
-        clientDolphin.delete(model)
+        clientDolphin.getModelStore().delete(model)
         // ... it is no longer in the client model store
         assert !clientDolphin.getModelStore().findPresentationModelById(modelId)
         // ... all listeners have been detached from model and all its attributes
@@ -92,7 +93,7 @@ class DeletePresentationModelTests extends GroovyTestCase {
     void testCreateAndDeletePresentationModelFromServer() {
         // create the pm
         String modelId = 'modelId'
-        def model = clientDolphin.presentationModel(modelId, someAttribute:"someValue")
+        def model = clientDolphin.getModelStore().createModel(modelId, null, new ClientAttribute("someAttribute", "someValue"))
         // the model is in the client model store
         def found = clientDolphin.getModelStore().findPresentationModelById(modelId)
         assert model == found
@@ -109,7 +110,7 @@ class DeletePresentationModelTests extends GroovyTestCase {
             }
         });
         // when we now delete the pm
-        clientDolphin.send(new TriggerDeleteCommand(), new OnFinishedHandler() {
+        clientDolphin.getClientConnector().send(new TriggerDeleteCommand(), new OnFinishedHandler() {
             @Override
             void onFinished() {
                 clientDolphin.sync {

--- a/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/comm/TestInMemoryConfig.java
+++ b/remoting/dolphin-remoting-combined/src/test/groovy/org/opendolphin/core/comm/TestInMemoryConfig.java
@@ -35,7 +35,7 @@ public class TestInMemoryConfig extends DefaultInMemoryConfig {
 
     public TestInMemoryConfig(Executor uiExecutor) {
         super(uiExecutor);
-        getServerDolphin().registerDefaultActions();
+        getServerDolphin().getServerConnector().registerDefaultActions();
         getClientConnector().setSleepMillis(0);
     }
 

--- a/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/ServerDolphin.java
+++ b/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/ServerDolphin.java
@@ -16,17 +16,12 @@
 package org.opendolphin.core.server;
 
 import org.opendolphin.core.Dolphin;
-import org.opendolphin.core.server.action.DolphinServerAction;
 
+@Deprecated
 public interface ServerDolphin extends Dolphin<ServerAttribute, ServerPresentationModel> {
 
     ServerConnector getServerConnector();
 
-    void registerDefaultActions();
-
-    void register(DolphinServerAction action);
-
     ServerModelStore getModelStore();
 
-     ServerPresentationModel presentationModel(String id, String presentationModelType, DTO dto);
 }

--- a/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/ServerModelStore.java
+++ b/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/ServerModelStore.java
@@ -183,4 +183,29 @@ public class ServerModelStore extends ModelStore<ServerAttribute, ServerPresenta
         }
         response.add(new CreatePresentationModelCommand(id, presentationModelType, list));
     }
+
+    /**
+     * Create a presentation model on the server side, add it to the model store, and send a command to
+     * the client, advising him to do the same.
+     *
+     * @throws IllegalArgumentException if a presentation model for this id already exists. No commands are sent in this case.
+     */
+    public ServerPresentationModel presentationModel(String id, String presentationModelType, DTO dto) {
+        List<ServerAttribute> attributes = new ArrayList<ServerAttribute>();
+        for (final Slot slot : dto.getSlots()) {
+            final ServerAttribute result = new ServerAttribute(slot.getPropertyName(), slot.getValue(), slot.getQualifier());
+            result.silently(new Runnable() {
+                @Override
+                public void run() {
+                    result.setValue(slot.getValue());
+                }
+
+            });
+            attributes.add(result);
+        }
+        ServerPresentationModel model = new ServerPresentationModel(id, attributes, this);
+        model.setPresentationModelType(presentationModelType);
+        add(model);
+        return model;
+    }
 }

--- a/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/action/CreatePresentationModelAction.java
+++ b/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/action/CreatePresentationModelAction.java
@@ -17,8 +17,8 @@ package org.opendolphin.core.server.action;
 
 import org.opendolphin.RemotingConstants;
 import org.opendolphin.core.comm.CreatePresentationModelCommand;
-import org.opendolphin.core.server.DefaultServerDolphin;
 import org.opendolphin.core.server.ServerAttribute;
+import org.opendolphin.core.server.ServerModelStore;
 import org.opendolphin.core.server.ServerPresentationModel;
 import org.opendolphin.core.server.comm.ActionRegistry;
 import org.opendolphin.core.server.comm.CommandHandler;
@@ -37,13 +37,13 @@ public class CreatePresentationModelAction extends DolphinServerAction {
         registry.register(CreatePresentationModelCommand.class, new CommandHandler<CreatePresentationModelCommand>() {
             @Override
             public void handleCommand(final CreatePresentationModelCommand command, List response) {
-                createPresentationModel(command, getServerDolphin());// closure wrapper for correct scoping and extracted method for static compilation
+                createPresentationModel(command, getServerModelStore());
             }
         });
     }
 
-    private static void createPresentationModel(CreatePresentationModelCommand command, DefaultServerDolphin serverDolphin) {
-        if (serverDolphin.getModelStore().findPresentationModelById(command.getPmId()) != null) {
+    private static void createPresentationModel(CreatePresentationModelCommand command, ServerModelStore serverModelStore) {
+        if (serverModelStore.findPresentationModelById(command.getPmId()) != null) {
             LOG.info("Ignoring create PM '" + command.getPmId() + "' since it is already in the model store.");
             return;
         }
@@ -59,9 +59,9 @@ public class CreatePresentationModelAction extends DolphinServerAction {
             attributes.add(attribute);
         }
 
-        ServerPresentationModel model = new ServerPresentationModel(command.getPmId(), attributes, serverDolphin.getServerModelStore());
+        ServerPresentationModel model = new ServerPresentationModel(command.getPmId(), attributes, serverModelStore);
         model.setPresentationModelType(command.getPmType());
-        serverDolphin.getServerModelStore().checkClientAdded(model);
+        serverModelStore.checkClientAdded(model);
     }
 
 }

--- a/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/action/DeletePresentationModelAction.java
+++ b/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/action/DeletePresentationModelAction.java
@@ -28,8 +28,8 @@ public class DeletePresentationModelAction extends DolphinServerAction {
         registry.register(DeletedPresentationModelNotification.class, new CommandHandler<DeletedPresentationModelNotification>() {
             @Override
             public void handleCommand(final DeletedPresentationModelNotification command, List response) {
-                ServerPresentationModel model = getServerDolphin().getModelStore().findPresentationModelById(command.getPmId());
-                getServerDolphin().getServerModelStore().checkClientRemoved(model);
+                ServerPresentationModel model = getServerModelStore().findPresentationModelById(command.getPmId());
+                getServerModelStore().checkClientRemoved(model);
             }
         });
     }

--- a/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/action/DolphinServerAction.java
+++ b/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/action/DolphinServerAction.java
@@ -17,7 +17,6 @@ package org.opendolphin.core.server.action;
 
 import org.opendolphin.core.comm.Command;
 import org.opendolphin.core.server.DTO;
-import org.opendolphin.core.server.DefaultServerDolphin;
 import org.opendolphin.core.server.ServerAttribute;
 import org.opendolphin.core.server.ServerModelStore;
 
@@ -29,7 +28,7 @@ import java.util.List;
  */
 public abstract class DolphinServerAction implements ServerAction {
 
-    private DefaultServerDolphin serverDolphin;
+    private ServerModelStore serverModelStore;
 
     private List<Command> dolphinResponse;
 
@@ -41,12 +40,13 @@ public abstract class DolphinServerAction implements ServerAction {
         ServerModelStore.changeValueCommand(dolphinResponse, attribute, value);
     }
 
-    public DefaultServerDolphin getServerDolphin() {
-        return serverDolphin;
+    public ServerModelStore getServerModelStore() {
+        return serverModelStore;
     }
 
-    public void setServerDolphin(DefaultServerDolphin serverDolphin) {
-        this.serverDolphin = serverDolphin;
+    @Deprecated
+    public void setServerModelStore(ServerModelStore serverModelStore) {
+        this.serverModelStore = serverModelStore;
     }
 
     public List<Command> getDolphinResponse() {

--- a/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/action/StoreAttributeAction.java
+++ b/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/action/StoreAttributeAction.java
@@ -32,7 +32,7 @@ public class StoreAttributeAction extends DolphinServerAction {
         registry.register(ChangeAttributeMetadataCommand.class, new CommandHandler<ChangeAttributeMetadataCommand>() {
             @Override
             public void handleCommand(final ChangeAttributeMetadataCommand command, List response) {
-                final Attribute attribute = getServerDolphin().getModelStore().findAttributeById(command.getAttributeId());
+                final Attribute attribute = getServerModelStore().findAttributeById(command.getAttributeId());
                 if (attribute == null) {
                     LOG.warning("Cannot find attribute with id '" + command.getAttributeId() + "'. Metadata remains unchanged.");
                     return;

--- a/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/action/StoreValueChangeAction.java
+++ b/remoting/dolphin-remoting-server/src/main/java/org/opendolphin/core/server/action/StoreValueChangeAction.java
@@ -32,7 +32,7 @@ public class StoreValueChangeAction extends DolphinServerAction {
         registry.register(ValueChangedCommand.class, new CommandHandler<ValueChangedCommand>() {
             @Override
             public void handleCommand(final ValueChangedCommand command, List response) {
-                final ServerAttribute attribute = getServerDolphin().getModelStore().findAttributeById(command.getAttributeId());
+                final ServerAttribute attribute = getServerModelStore().findAttributeById(command.getAttributeId());
                 if (attribute != null) {
                     if (! Objects.equals(attribute.getValue(), command.getOldValue())) {
                         LOG.warning("S: updating attribute with id '" + command.getAttributeId() + "' to new value '" + command.getNewValue() + "' even though its old command value '" + command.getOldValue() + "' does not conform to the old value of '" + attribute.getValue() + "'. Client overrules server.");

--- a/remoting/dolphin-remoting-server/src/test/groovy/org/opendolphin/core/server/ServerDolphinTest.groovy
+++ b/remoting/dolphin-remoting-server/src/test/groovy/org/opendolphin/core/server/ServerDolphinTest.groovy
@@ -24,7 +24,7 @@ public class ServerDolphinTest extends GroovyTestCase {
     @Override
     protected void setUp() throws Exception {
         dolphin = ServerDolphinFactory.create()
-        dolphin.serverModelStore.currentResponse = []
+        dolphin.getModelStore().currentResponse = []
     }
 
     void testListPresentationModels() {
@@ -33,13 +33,13 @@ public class ServerDolphinTest extends GroovyTestCase {
         assert dolphin.getModelStore().findAllAttributesByQualifier("no-such-qualifier").empty
         assert dolphin.getModelStore().findAllPresentationModelsByType("no-such-type").empty
 
-        def pm1 = new ServerPresentationModel("first", [], dolphin.serverModelStore)
+        def pm1 = new ServerPresentationModel("first", [], dolphin.getModelStore())
         dolphin.getModelStore().add pm1
 
         assert ['first'].toSet() == dolphin.getModelStore().listPresentationModelIds()
         assert [pm1] == dolphin.getModelStore().listPresentationModels().toList()
 
-        def pm2 = new ServerPresentationModel("second", [], dolphin.serverModelStore)
+        def pm2 = new ServerPresentationModel("second", [], dolphin.getModelStore())
         dolphin.getModelStore().add pm2
 
         assert 2 == dolphin.getModelStore().listPresentationModelIds().size()
@@ -67,11 +67,11 @@ public class ServerDolphinTest extends GroovyTestCase {
         }
         dolphin.getModelStore().addModelStoreListener 'person', typedListener
         dolphin.getModelStore().addModelStoreListener listener
-        dolphin.getModelStore().add(new ServerPresentationModel('p1', [], dolphin.serverModelStore))
-        ServerPresentationModel modelWithType = new ServerPresentationModel('person1', [], dolphin.serverModelStore)
+        dolphin.getModelStore().add(new ServerPresentationModel('p1', [], dolphin.getModelStore()))
+        ServerPresentationModel modelWithType = new ServerPresentationModel('person1', [], dolphin.getModelStore())
         modelWithType.setPresentationModelType('person')
         dolphin.getModelStore().add(modelWithType)
-        dolphin.getModelStore().add(new ServerPresentationModel('p2', [], dolphin.serverModelStore))
+        dolphin.getModelStore().add(new ServerPresentationModel('p2', [], dolphin.getModelStore()))
         dolphin.getModelStore().removeModelStoreListener 'person', typedListener
         dolphin.getModelStore().removeModelStoreListener listener
         assert 3 == listenerCallCount
@@ -85,11 +85,11 @@ public class ServerDolphinTest extends GroovyTestCase {
         int listenerCallCount = 0
         dolphin.getModelStore().addModelStoreListener 'person', { evt -> typedListenerCallCount++ }
         dolphin.getModelStore().addModelStoreListener { evt -> listenerCallCount++ }
-        dolphin.getModelStore().add(new ServerPresentationModel('p1', [], dolphin.serverModelStore))
-        ServerPresentationModel modelWithType = new ServerPresentationModel('person1', [], dolphin.serverModelStore)
+        dolphin.getModelStore().add(new ServerPresentationModel('p1', [], dolphin.getModelStore()))
+        ServerPresentationModel modelWithType = new ServerPresentationModel('person1', [], dolphin.getModelStore())
         modelWithType.setPresentationModelType('person')
         dolphin.getModelStore().add(modelWithType)
-        dolphin.getModelStore().add(new ServerPresentationModel('p2', [], dolphin.serverModelStore))
+        dolphin.getModelStore().add(new ServerPresentationModel('p2', [], dolphin.getModelStore()))
         assert 3 == listenerCallCount
         assert 1 == typedListenerCallCount
     }
@@ -107,11 +107,11 @@ public class ServerDolphinTest extends GroovyTestCase {
     }
 
     void testRegisterDefaultActions() {
-        dolphin.registerDefaultActions();
+        dolphin.getServerConnector().registerDefaultActions();
         def numDefaultActions = dolphin.serverConnector.dolphinServerActions.size()
 
         // multiple calls should not lead to multiple initializations
-        dolphin.registerDefaultActions();
+        dolphin.getServerConnector().registerDefaultActions();
         assert numDefaultActions == dolphin.serverConnector.dolphinServerActions.size()
     }
 

--- a/remoting/dolphin-remoting-server/src/test/groovy/org/opendolphin/core/server/action/StoreAttributeActionTests.groovy
+++ b/remoting/dolphin-remoting-server/src/test/groovy/org/opendolphin/core/server/action/StoreAttributeActionTests.groovy
@@ -29,14 +29,14 @@ class StoreAttributeActionTests extends GroovyTestCase {
     @Override
     protected void setUp() throws Exception {
         dolphin = ServerDolphinFactory.create()
-        dolphin.serverModelStore.currentResponse = []
+        dolphin.getModelStore().currentResponse = []
         registry = new ActionRegistry()
     }
 
     void testChangeAttributeMetadata() {
-        new StoreAttributeAction(serverDolphin: dolphin).registerIn registry
+        new StoreAttributeAction(serverModelStore: dolphin.modelStore).registerIn registry
         ServerAttribute attribute = new ServerAttribute('newAttribute', '')
-        dolphin.getModelStore().add(new ServerPresentationModel('model', [attribute], dolphin.serverModelStore))
+        dolphin.getModelStore().add(new ServerPresentationModel('model', [attribute], dolphin.getModelStore()))
         registry.getActionsFor(ChangeAttributeMetadataCommand.class).first().handleCommand(new ChangeAttributeMetadataCommand(attributeId: attribute.id, metadataName: 'value', value: 'newValue'), [])
         assert 'newValue' == attribute.value
     }

--- a/remoting/dolphin-remoting-shared/src/main/java/org/opendolphin/core/Dolphin.java
+++ b/remoting/dolphin-remoting-shared/src/main/java/org/opendolphin/core/Dolphin.java
@@ -15,6 +15,7 @@
  */
 package org.opendolphin.core;
 
+@Deprecated
 public interface Dolphin<A extends Attribute, P extends PresentationModel<A>> {
 
     ModelStore<A, P> getModelStore();

--- a/remoting/dolphin-remoting-shared/src/main/java/org/opendolphin/core/ModelStore.java
+++ b/remoting/dolphin-remoting-shared/src/main/java/org/opendolphin/core/ModelStore.java
@@ -291,6 +291,7 @@ public class ModelStore<A extends Attribute, P extends PresentationModel<A>> {
      * @param attribute attribute to be added to the model store
      * @see #add(PresentationModel)
      */
+    @Deprecated
     public void registerAttribute(A attribute) {
         if (null == attribute) return;
         boolean listeningAlready = false;

--- a/remoting/dolphin-remoting-shared/src/main/java/org/opendolphin/util/Provider.java
+++ b/remoting/dolphin-remoting-shared/src/main/java/org/opendolphin/util/Provider.java
@@ -1,0 +1,6 @@
+package org.opendolphin.util;
+
+public interface Provider<T> {
+
+    T get();
+}


### PR DESCRIPTION
ServerDolphin & ClientDolphin deprecated
removed direct dependency from ModelStore to client connector

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/427)
<!-- Reviewable:end -->
