### PR TITLE
Fix to inject EventBus before DP bootstrap is done

### DIFF
--- a/platform/dolphin-platform-remoting-server/src/main/java/com/canoo/dp/impl/server/event/LazyEventBusInvocationHandler.java
+++ b/platform/dolphin-platform-remoting-server/src/main/java/com/canoo/dp/impl/server/event/LazyEventBusInvocationHandler.java
@@ -2,6 +2,7 @@ package com.canoo.dp.impl.server.event;
 
 import com.canoo.dp.impl.server.bootstrap.PlatformBootstrap;
 import com.canoo.platform.remoting.server.event.DolphinEventBus;
+import com.canoo.platform.server.spi.ServerCoreComponents;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -12,9 +13,12 @@ public class LazyEventBusInvocationHandler implements InvocationHandler {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        final DolphinEventBus instance = PlatformBootstrap.getServerCoreComponents().getInstance(DolphinEventBus.class);
-        if (instance != null) {
-            return method.invoke(instance, args);
+        final ServerCoreComponents serverCoreComponents = PlatformBootstrap.getServerCoreComponents();
+        if(serverCoreComponents != null) {
+            final DolphinEventBus instance = serverCoreComponents.getInstance(DolphinEventBus.class);
+            if (instance != null) {
+                return method.invoke(instance, args);
+            }
         }
         if(method.getDeclaringClass().equals(Object.class)) {
             return method.invoke(DUMMY_OBJECT, args);


### PR DESCRIPTION
Fix to inject EventBus before DP bootstrap is done
Fix for https://github.com/canoo/dolphin-platform/issues/577

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/583)
<!-- Reviewable:end -->
