### PR TITLE
Moving validation classes to private API package

### DIFF
--- a/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/AbstractPropertyValidator.java
+++ b/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/AbstractPropertyValidator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.dolphin.validation;
+package com.canoo.dp.impl.validation;
 
 import com.canoo.platform.remoting.Property;
 

--- a/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/AssertFalsePropertyValidator.java
+++ b/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/AssertFalsePropertyValidator.java
@@ -13,30 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.dolphin.validation;
+package com.canoo.dp.impl.validation;
 
-import com.canoo.platform.remoting.Property;
-
-import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.AssertFalse;
 
 /**
- * Validator that adds Dolphin Platform property support for the {@link NotNull} annotation.
+ * Validator that adds Dolphin Platform property support for the {@link AssertFalse} annotation.
  */
-public final class NotNullPropertyValidator implements ConstraintValidator<NotNull, Property> {
+public final class AssertFalsePropertyValidator extends AbstractPropertyValidator<AssertFalse, Boolean> {
 
-    @Override
-    public void initialize(NotNull constraintAnnotation) {
+    /**
+     * constructor
+     */
+    public AssertFalsePropertyValidator() {
+        super(Boolean.class);
     }
 
     @Override
-    public boolean isValid(Property value,
-                           ConstraintValidatorContext context) {
-        if (value == null || value.get() == null) {
-            return false;
-        }
-        return true;
+    protected boolean checkValid(Boolean property, ConstraintValidatorContext context) {
+        return !property;
     }
 
 }

--- a/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/AssertTruePropertyValidator.java
+++ b/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/AssertTruePropertyValidator.java
@@ -13,9 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * This package contains several validator implementations for the JSR-303 Java Bean Validation.
- * All the classes will be used automatically since the JSR provides a plugin structure that is implemented by this
- * module (see META-INF/mapping/validation.xml)
+package com.canoo.dp.impl.validation;
+
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.constraints.AssertTrue;
+
+/**
+ * Validator that adds Dolphin Platform property support for the {@link AssertTrue} annotation.
  */
-package com.canoo.dolphin.validation;
+public final class AssertTruePropertyValidator extends AbstractPropertyValidator<AssertTrue, Boolean> {
+
+    /**
+     * constructor
+     */
+    public AssertTruePropertyValidator() {
+        super(Boolean.class);
+    }
+
+    @Override
+    protected boolean checkValid(Boolean property, ConstraintValidatorContext context) {
+        return property;
+    }
+
+}
+

--- a/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/DecimalMaxPropertyValidatorForNumber.java
+++ b/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/DecimalMaxPropertyValidatorForNumber.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.dolphin.validation;
+package com.canoo.dp.impl.validation;
 
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.ValidationException;

--- a/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/DecimalMinPropertyValidatorForNumber.java
+++ b/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/DecimalMinPropertyValidatorForNumber.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.dolphin.validation;
+package com.canoo.dp.impl.validation;
 
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.constraints.DecimalMin;

--- a/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/NotNullPropertyValidator.java
+++ b/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/NotNullPropertyValidator.java
@@ -13,33 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.dolphin.validation;
+package com.canoo.dp.impl.validation;
 
 import com.canoo.platform.remoting.Property;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-import javax.validation.constraints.Null;
+import javax.validation.constraints.NotNull;
 
 /**
- * Validator that adds Dolphin Platform property support for the {@link Null} annotation.
+ * Validator that adds Dolphin Platform property support for the {@link NotNull} annotation.
  */
-public final class NullPropertyValidator implements ConstraintValidator<Null, Property> {
+public final class NotNullPropertyValidator implements ConstraintValidator<NotNull, Property> {
 
     @Override
-    public void initialize(Null constraintAnnotation) {
+    public void initialize(NotNull constraintAnnotation) {
     }
 
     @Override
     public boolean isValid(Property value,
                            ConstraintValidatorContext context) {
-        if (value == null) {
-            return true;
+        if (value == null || value.get() == null) {
+            return false;
         }
-        if (value.get() == null) {
-            return true;
-        }
-        return false;
+        return true;
     }
 
 }

--- a/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/NullPropertyValidator.java
+++ b/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/NullPropertyValidator.java
@@ -13,26 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.dolphin.validation;
+package com.canoo.dp.impl.validation;
 
+import com.canoo.platform.remoting.Property;
+
+import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Null;
 
 /**
- * Validator that adds Dolphin Platform property support for the {@link AssertTrue} annotation.
+ * Validator that adds Dolphin Platform property support for the {@link Null} annotation.
  */
-public final class AssertTruePropertyValidator extends AbstractPropertyValidator<AssertTrue, Boolean> {
+public final class NullPropertyValidator implements ConstraintValidator<Null, Property> {
 
-    /**
-     * constructor
-     */
-    public AssertTruePropertyValidator() {
-        super(Boolean.class);
+    @Override
+    public void initialize(Null constraintAnnotation) {
     }
 
     @Override
-    protected boolean checkValid(Boolean property, ConstraintValidatorContext context) {
-        return property;
+    public boolean isValid(Property value,
+                           ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        if (value.get() == null) {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/package-info.java
+++ b/platform-extras/dolphin-platform-bean-validation/src/main/java/com/canoo/dp/impl/validation/package-info.java
@@ -13,27 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.dolphin.validation;
-
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.constraints.AssertFalse;
-
-/**
- * Validator that adds Dolphin Platform property support for the {@link AssertFalse} annotation.
+/*
+ * This package contains several validator implementations for the JSR-303 Java Bean Validation.
+ * All the classes will be used automatically since the JSR provides a plugin structure that is implemented by this
+ * module (see META-INF/mapping/validation.xml)
  */
-public final class AssertFalsePropertyValidator extends AbstractPropertyValidator<AssertFalse, Boolean> {
-
-    /**
-     * constructor
-     */
-    public AssertFalsePropertyValidator() {
-        super(Boolean.class);
-    }
-
-    @Override
-    protected boolean checkValid(Boolean property, ConstraintValidatorContext context) {
-        return !property;
-    }
-
-}
-
+package com.canoo.dp.impl.validation;

--- a/platform-extras/dolphin-platform-bean-validation/src/main/resources/META-INF/mapping/validationMappingDolphinPlatform.xml
+++ b/platform-extras/dolphin-platform-bean-validation/src/main/resources/META-INF/mapping/validationMappingDolphinPlatform.xml
@@ -23,37 +23,37 @@
 
     <constraint-definition annotation="javax.validation.constraints.AssertFalse">
         <validated-by include-existing-validators="true">
-            <value>com.canoo.dolphin.validation.AssertFalsePropertyValidator</value>
+            <value>com.canoo.dp.impl.validation.AssertFalsePropertyValidator</value>
         </validated-by>
     </constraint-definition>
 
     <constraint-definition annotation="javax.validation.constraints.AssertTrue">
         <validated-by include-existing-validators="true">
-            <value>com.canoo.dolphin.validation.AssertTruePropertyValidator</value>
+            <value>com.canoo.dp.impl.validation.AssertTruePropertyValidator</value>
         </validated-by>
     </constraint-definition>
 
     <constraint-definition annotation="javax.validation.constraints.DecimalMax">
         <validated-by include-existing-validators="true">
-            <value>com.canoo.dolphin.validation.DecimalMaxPropertyValidatorForNumber</value>
+            <value>com.canoo.dp.impl.validation.DecimalMaxPropertyValidatorForNumber</value>
         </validated-by>
     </constraint-definition>
 
     <constraint-definition annotation="javax.validation.constraints.DecimalMin">
         <validated-by include-existing-validators="true">
-            <value>com.canoo.dolphin.validation.DecimalMinPropertyValidatorForNumber</value>
+            <value>com.canoo.dp.impl.validation.DecimalMinPropertyValidatorForNumber</value>
         </validated-by>
     </constraint-definition>
 
     <constraint-definition annotation="javax.validation.constraints.NotNull">
         <validated-by include-existing-validators="true">
-            <value>com.canoo.dolphin.validation.NotNullPropertyValidator</value>
+            <value>com.canoo.dp.impl.validation.NotNullPropertyValidator</value>
         </validated-by>
     </constraint-definition>
     
     <constraint-definition annotation="javax.validation.constraints.Null">
         <validated-by include-existing-validators="true">
-            <value>com.canoo.dolphin.validation.NullPropertyValidator</value>
+            <value>com.canoo.dp.impl.validation.NullPropertyValidator</value>
         </validated-by>
     </constraint-definition>
 

--- a/platform-extras/dolphin-platform-bean-validation/src/test/java/com/canoo/dp/impl/validation/TestBean.java
+++ b/platform-extras/dolphin-platform-bean-validation/src/test/java/com/canoo/dp/impl/validation/TestBean.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.dolphin.validation;
+package com.canoo.dp.impl.validation;
 
 import com.canoo.dp.impl.remoting.MockedProperty;
 import com.canoo.platform.remoting.DolphinBean;

--- a/platform-extras/dolphin-platform-bean-validation/src/test/java/com/canoo/dp/impl/validation/ValidationTest.java
+++ b/platform-extras/dolphin-platform-bean-validation/src/test/java/com/canoo/dp/impl/validation/ValidationTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.dolphin.validation;
+package com.canoo.dp.impl.validation;
 
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
All classes are moved to the default private API package of DP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/639)
<!-- Reviewable:end -->
