### PR TITLE
Rename AbstractViewBinder to AbstractViewController (Issue #634)

### DIFF
--- a/platform-examples/process-monitor-sample/process-monitor-client-javafx/src/main/java/com/canoo/dolphin/samples/processmonitor/ProcessMonitorView.java
+++ b/platform-examples/process-monitor-sample/process-monitor-client-javafx/src/main/java/com/canoo/dolphin/samples/processmonitor/ProcessMonitorView.java
@@ -18,7 +18,7 @@ package com.canoo.dolphin.samples.processmonitor;
 import com.canoo.platform.remoting.client.ClientContext;
 import com.canoo.platform.remoting.client.javafx.FXBinder;
 import com.canoo.platform.remoting.client.javafx.binding.FXWrapper;
-import com.canoo.platform.remoting.client.javafx.view.AbstractViewBinder;
+import com.canoo.platform.remoting.client.javafx.view.AbstractViewController;
 import com.canoo.dolphin.samples.processmonitor.model.ProcessBean;
 import com.canoo.dolphin.samples.processmonitor.model.ProcessListBean;
 import javafx.scene.Node;
@@ -27,7 +27,7 @@ import javafx.scene.control.TableView;
 
 import static com.canoo.dolphin.samples.processmonitor.ProcessMonitorConstants.CONTROLLER_NAME;
 
-public class ProcessMonitorView extends AbstractViewBinder<ProcessListBean> {
+public class ProcessMonitorView extends AbstractViewController<ProcessListBean> {
 
     private TableView<ProcessBean> table;
 

--- a/platform-examples/todo-example/todo-client/src/main/java/com/canoo/dolphin/todo/client/ToDoView.java
+++ b/platform-examples/todo-example/todo-client/src/main/java/com/canoo/dolphin/todo/client/ToDoView.java
@@ -17,7 +17,7 @@ package com.canoo.dolphin.todo.client;
 
 import com.canoo.platform.remoting.client.ClientContext;
 import com.canoo.platform.remoting.client.javafx.FXBinder;
-import com.canoo.platform.remoting.client.javafx.view.AbstractFXMLViewBinder;
+import com.canoo.platform.remoting.client.javafx.view.AbstractFXMLViewController;
 import com.canoo.dolphin.todo.pm.ToDoItem;
 import com.canoo.dolphin.todo.pm.ToDoList;
 import javafx.fxml.FXML;
@@ -28,7 +28,7 @@ import javafx.scene.control.TextField;
 import static com.canoo.dolphin.todo.TodoAppConstants.ADD_ACTION;
 import static com.canoo.dolphin.todo.TodoAppConstants.TODO_CONTROLLER_NAME;
 
-public class ToDoView extends AbstractFXMLViewBinder<ToDoList> {
+public class ToDoView extends AbstractFXMLViewController<ToDoList> {
 
     @FXML
     private TextField createField;

--- a/platform-examples/web-deployment-example/web-deployment-client/src/main/java/com/canoo/dolphin/webdeployment/client/view/MyView.java
+++ b/platform-examples/web-deployment-example/web-deployment-client/src/main/java/com/canoo/dolphin/webdeployment/client/view/MyView.java
@@ -18,7 +18,7 @@ package com.canoo.dolphin.webdeployment.client.view;
 import com.canoo.platform.remoting.client.ClientContext;
 import com.canoo.platform.remoting.client.javafx.FXBinder;
 
-import com.canoo.platform.remoting.client.javafx.view.AbstractFXMLViewBinder;
+import com.canoo.platform.remoting.client.javafx.view.AbstractFXMLViewController;
 import com.canoo.dolphin.webdeployment.Constants;
 import com.canoo.dolphin.webdeployment.model.MyModel;
 import javafx.fxml.FXML;
@@ -26,7 +26,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.TextField;
 
 
-public class MyView extends AbstractFXMLViewBinder<MyModel> {
+public class MyView extends AbstractFXMLViewController<MyModel> {
 
     @FXML
     private TextField valueField;

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/view/AbstractFXMLViewController.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/view/AbstractFXMLViewController.java
@@ -29,11 +29,11 @@ import java.net.URL;
  * By creating new instances of classes that extend this class a JavaFX view will be automatically created by using the
  * given FXML file. In addition the {@link javafx.fxml.FXML} annotation can be used in that classes.
  *
- * For information about the Dolphin Platform based behavior of this class see {@link AbstractViewBinder}.
+ * For information about the Dolphin Platform based behavior of this class see {@link AbstractViewController}.
  *
  * @param <M> type of the model.
  */
-public abstract class AbstractFXMLViewBinder<M> extends AbstractViewBinder<M> {
+public abstract class AbstractFXMLViewController<M> extends AbstractViewController<M> {
 
     private final Node rootNode;
 
@@ -44,7 +44,7 @@ public abstract class AbstractFXMLViewBinder<M> extends AbstractViewBinder<M> {
      *                       be used with this view.
      * @param fxmlLocation the location (url) of the FXML file that defines the layout of the view.
      */
-    public AbstractFXMLViewBinder(ClientContext clientContext, String controllerName, URL fxmlLocation) {
+    public AbstractFXMLViewController(ClientContext clientContext, String controllerName, URL fxmlLocation) {
         super(clientContext, controllerName);
         Assert.requireNonNull(fxmlLocation, "fxmlLocation");
         try {

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/view/AbstractViewController.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/view/AbstractViewController.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CompletableFuture;
  * a model (see {@link DolphinBean}) with the view.
  * @param <M> type of the model
  */
-public abstract class AbstractViewBinder<M> {
+public abstract class AbstractViewController<M> {
 
     private ControllerProxy<M> controllerProxy;
 
@@ -55,7 +55,7 @@ public abstract class AbstractViewBinder<M> {
      * @param clientContext the client context
      * @param controllerName name of the controller (see annotation DolphinController in the Java server lib).
      */
-    public AbstractViewBinder(ClientContext clientContext, String controllerName) {
+    public AbstractViewController(ClientContext clientContext, String controllerName) {
         Assert.requireNonBlank(controllerName, "controllerName");
         this.clientContext = Assert.requireNonNull(clientContext, "clientContext");
         clientContext.<M>createController(controllerName).whenComplete((c, e) -> {
@@ -224,7 +224,7 @@ public abstract class AbstractViewBinder<M> {
 
     /**
      * Usefull helper method that returns the root node (see {@link #getRootNode()}) as a {@link Parent} if the root node
-     * extends {@link Parent} or throws an runtime exception. This can be used to simply add a {@link AbstractFXMLViewBinder}
+     * extends {@link Parent} or throws an runtime exception. This can be used to simply add a {@link AbstractFXMLViewController}
      * based view to a scene that needs a {@link Parent} as a root node.
      * @return the root node
      */

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/window/DolphinStage.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/window/DolphinStage.java
@@ -15,14 +15,14 @@
  */
 package com.canoo.platform.remoting.client.javafx.window;
 
-import com.canoo.platform.remoting.client.javafx.view.AbstractViewBinder;
+import com.canoo.platform.remoting.client.javafx.view.AbstractViewController;
 import com.canoo.dp.impl.platform.core.Assert;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
 /**
- * A JavaFX {@link Stage} that contains the view of a {@link AbstractViewBinder} and will automatically call
- * {@link AbstractViewBinder#destroy()} when the stage becomes hidden.
+ * A JavaFX {@link Stage} that contains the view of a {@link AbstractViewController} and will automatically call
+ * {@link AbstractViewController#destroy()} when the stage becomes hidden.
  * @param <M> type of the model
  */
 @Deprecated
@@ -32,7 +32,7 @@ public class DolphinStage<M> extends Stage {
      * Constructor
      * @param viewBinder the viewBinder
      */
-    public DolphinStage(final AbstractViewBinder<M> viewBinder) {
+    public DolphinStage(final AbstractViewController<M> viewBinder) {
         Assert.requireNonNull(viewBinder, "viewBinder");
         DolphinWindowUtils.destroyOnClose(this, viewBinder);
         setScene(new Scene(viewBinder.getParent()));

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/window/DolphinWindow.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/window/DolphinWindow.java
@@ -15,14 +15,14 @@
  */
 package com.canoo.platform.remoting.client.javafx.window;
 
-import com.canoo.platform.remoting.client.javafx.view.AbstractViewBinder;
+import com.canoo.platform.remoting.client.javafx.view.AbstractViewController;
 import com.canoo.dp.impl.platform.core.Assert;
 import javafx.scene.Scene;
 import javafx.stage.Window;
 
 /**
- * A JavaFX {@link Window} that contains the view of a {@link AbstractViewBinder} and will automatically call
- * {@link AbstractViewBinder#destroy()} when the stage becomes hidden.
+ * A JavaFX {@link Window} that contains the view of a {@link AbstractViewController} and will automatically call
+ * {@link AbstractViewController#destroy()} when the stage becomes hidden.
  *
  * @param <M> type of the model
  */
@@ -34,7 +34,7 @@ public class DolphinWindow<M> extends Window {
      *
      * @param viewBinder the viewBinder
      */
-    public DolphinWindow(final AbstractViewBinder<M> viewBinder) {
+    public DolphinWindow(final AbstractViewController<M> viewBinder) {
         Assert.requireNonNull(viewBinder, "viewBinder");
         DolphinWindowUtils.destroyOnClose(this, viewBinder);
         setScene(new Scene(viewBinder.getParent()));

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/window/DolphinWindowUtils.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/window/DolphinWindowUtils.java
@@ -15,7 +15,7 @@
  */
 package com.canoo.platform.remoting.client.javafx.window;
 
-import com.canoo.platform.remoting.client.javafx.view.AbstractViewBinder;
+import com.canoo.platform.remoting.client.javafx.view.AbstractViewController;
 import com.canoo.platform.core.functional.Subscription;
 import com.canoo.dp.impl.platform.core.Assert;
 import javafx.event.EventHandler;
@@ -28,14 +28,14 @@ import javafx.stage.WindowEvent;
 public class DolphinWindowUtils {
 
     /**
-     * The method will register an event handler to the window that will automatically call the {@link AbstractViewBinder#destroy()}
+     * The method will register an event handler to the window that will automatically call the {@link AbstractViewController#destroy()}
      * method when the windows becomes hidden.
      * @param window the window
      * @param viewBinder the view binder
      * @param <M> the model type
      * @return a subscription to unsubsribe / deregister the handler.
      */
-    public static <M> Subscription destroyOnClose(final Window window, final AbstractViewBinder<M> viewBinder) {
+    public static <M> Subscription destroyOnClose(final Window window, final AbstractViewController<M> viewBinder) {
         Assert.requireNonNull(window, "window");
         Assert.requireNonNull(viewBinder, "viewBinder");
         final EventHandler<WindowEvent> handler = e -> viewBinder.destroy();


### PR DESCRIPTION
Refactoring of Code and respective Javadoc (see Issue #634)

All occurrences of `AbstractViewBinder` are changed to `AbstractViewController` and all occurrences of `AbstractFXMLViewBinder` are changed to `AbstractFXMLViewController` in both Code and javadoc documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/643)
<!-- Reviewable:end -->
