### PR TITLE
Move Converter and BidirectionalConverter

### DIFF
--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/AbstractNumericDolphinBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/AbstractNumericDolphinBinder.java
@@ -17,7 +17,7 @@ package com.canoo.dp.impl.client.javafx;
 
 import com.canoo.platform.core.functional.Subscription;
 import com.canoo.platform.remoting.Binding;
-import com.canoo.platform.remoting.client.javafx.binding.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 import com.canoo.platform.remoting.client.javafx.binding.NumericDolphinBinder;
 import com.canoo.platform.remoting.Property;
 import javafx.beans.value.ChangeListener;

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/AbstractNumericJavaFXBidirectionalBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/AbstractNumericJavaFXBidirectionalBinder.java
@@ -15,7 +15,7 @@
  */
 package com.canoo.dp.impl.client.javafx;
 
-import com.canoo.platform.remoting.client.javafx.binding.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 import com.canoo.platform.remoting.Binding;
 import com.canoo.platform.remoting.client.javafx.binding.NumericJavaFXBidirectionaBinder;
 import com.canoo.platform.remoting.Property;

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/DefaultDolphinBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/DefaultDolphinBinder.java
@@ -15,9 +15,9 @@
  */
 package com.canoo.dp.impl.client.javafx;
 
-import com.canoo.platform.remoting.client.javafx.binding.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 import com.canoo.platform.remoting.Binding;
-import com.canoo.platform.remoting.client.javafx.binding.Converter;
+import com.canoo.platform.remoting.client.javafx.Converter;
 import com.canoo.platform.remoting.client.javafx.binding.DolphinBinder;
 import com.canoo.platform.core.functional.Subscription;
 import com.canoo.platform.remoting.Property;

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/DefaultJavaFXBidirectionalBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/DefaultJavaFXBidirectionalBinder.java
@@ -15,7 +15,7 @@
  */
 package com.canoo.dp.impl.client.javafx;
 
-import com.canoo.platform.remoting.client.javafx.binding.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 import com.canoo.platform.remoting.Binding;
 import com.canoo.platform.remoting.client.javafx.binding.JavaFXBidirectionalBinder;
 import com.canoo.platform.remoting.Property;

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/DefaultJavaFXBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/DefaultJavaFXBinder.java
@@ -16,7 +16,7 @@
 package com.canoo.dp.impl.client.javafx;
 
 import com.canoo.platform.remoting.Binding;
-import com.canoo.platform.remoting.client.javafx.binding.Converter;
+import com.canoo.platform.remoting.client.javafx.Converter;
 import com.canoo.platform.remoting.client.javafx.binding.JavaFXBinder;
 import com.canoo.platform.core.functional.Subscription;
 import com.canoo.platform.remoting.Property;

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/DoubleDolphinBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/DoubleDolphinBinder.java
@@ -15,7 +15,7 @@
  */
 package com.canoo.dp.impl.client.javafx;
 
-import com.canoo.platform.remoting.client.javafx.binding.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 import com.canoo.platform.remoting.Property;
 
 public class DoubleDolphinBinder extends AbstractNumericDolphinBinder<Double> {

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/FloatDolphinBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/FloatDolphinBinder.java
@@ -15,7 +15,7 @@
  */
 package com.canoo.dp.impl.client.javafx;
 
-import com.canoo.platform.remoting.client.javafx.binding.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 import com.canoo.platform.remoting.Property;
 
 public class FloatDolphinBinder extends AbstractNumericDolphinBinder<Float> {

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/IntegerDolphinBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/IntegerDolphinBinder.java
@@ -15,7 +15,7 @@
  */
 package com.canoo.dp.impl.client.javafx;
 
-import com.canoo.platform.remoting.client.javafx.binding.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 import com.canoo.platform.remoting.Property;
 
 public class IntegerDolphinBinder extends AbstractNumericDolphinBinder<Integer> {

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/LongDolphinBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/dp/impl/client/javafx/LongDolphinBinder.java
@@ -15,7 +15,7 @@
  */
 package com.canoo.dp.impl.client.javafx;
 
-import com.canoo.platform.remoting.client.javafx.binding.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 import com.canoo.platform.remoting.Property;
 
 public class LongDolphinBinder extends AbstractNumericDolphinBinder<Long> {

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/BidirectionalConverter.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/BidirectionalConverter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.platform.remoting.client.javafx.binding;
+package com.canoo.platform.remoting.client.javafx;
 
 /**
  * Defines a converter for a bidirectional binding. This converter type can be used to bind a JavaFX property

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/Converter.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/Converter.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.platform.remoting.client.javafx.binding;
+package com.canoo.platform.remoting.client.javafx;
 
 /**
  * Defines a converter that can convert a data type into a different data type. This converters are normally used to bind
- * JavaFX properties unidirectional to Dolphin Platform properties of a different type. For bidiertional bindings see {@link BidirectionalConverter}
+ * JavaFX properties unidirectional to Dolphin Platform properties of a different type. For bidirectional bindings see {@link BidirectionalConverter}
  * @param <T> type of the first data type
  * @param <U> type of the second data type
  */

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/binding/DefaultBidirectionalConverter.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/binding/DefaultBidirectionalConverter.java
@@ -16,6 +16,8 @@
 package com.canoo.platform.remoting.client.javafx.binding;
 
 import com.canoo.dp.impl.platform.core.Assert;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.Converter;
 
 @Deprecated
 public class DefaultBidirectionalConverter<T, U> implements BidirectionalConverter<T, U> {

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/binding/DolphinBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/binding/DolphinBinder.java
@@ -16,6 +16,8 @@
 package com.canoo.platform.remoting.client.javafx.binding;
 
 import com.canoo.platform.remoting.Binding;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.Converter;
 import com.canoo.platform.remoting.client.javafx.FXBinder;
 import javafx.beans.value.ObservableValue;
 

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/binding/JavaFXBidirectionalBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/binding/JavaFXBidirectionalBinder.java
@@ -16,6 +16,7 @@
 package com.canoo.platform.remoting.client.javafx.binding;
 
 import com.canoo.platform.remoting.Binding;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 import com.canoo.platform.remoting.client.javafx.FXBinder;
 import com.canoo.platform.remoting.Property;
 

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/binding/JavaFXBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/binding/JavaFXBinder.java
@@ -17,6 +17,7 @@ package com.canoo.platform.remoting.client.javafx.binding;
 
 import com.canoo.platform.remoting.Binding;
 import com.canoo.platform.remoting.Property;
+import com.canoo.platform.remoting.client.javafx.Converter;
 
 public interface JavaFXBinder<S> {
 

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/binding/NumericJavaFXBidirectionaBinder.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/binding/NumericJavaFXBidirectionaBinder.java
@@ -17,6 +17,7 @@ package com.canoo.platform.remoting.client.javafx.binding;
 
 import com.canoo.platform.remoting.Binding;
 import com.canoo.platform.remoting.Property;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 
 public interface NumericJavaFXBidirectionaBinder<S extends Number> extends JavaFXBidirectionalBinder<Number> {
 

--- a/platform/dolphin-platform-remoting-client-javafx/src/test/java/com/canoo/dolphin/client/javafx/FXBinderTest.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/test/java/com/canoo/dolphin/client/javafx/FXBinderTest.java
@@ -15,9 +15,9 @@
  */
 package com.canoo.dolphin.client.javafx;
 
-import com.canoo.platform.remoting.client.javafx.binding.BidirectionalConverter;
+import com.canoo.platform.remoting.client.javafx.BidirectionalConverter;
 import com.canoo.platform.remoting.Binding;
-import com.canoo.platform.remoting.client.javafx.binding.Converter;
+import com.canoo.platform.remoting.client.javafx.Converter;
 import com.canoo.platform.remoting.client.javafx.binding.DefaultBidirectionalConverter;
 import com.canoo.platform.remoting.client.javafx.FXBinder;
 import com.canoo.platform.remoting.ObservableList;


### PR DESCRIPTION
 Move Converter and BidirectionalConverter of JavaFX client API to com.canoo.platform.remoting.client.javafx

Fix typo in Converter JavaDoc
Remove BidirectionalConverter import from Converter

Fixes #635

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/645)
<!-- Reviewable:end -->
