### PR TITLE
Issue #633: Moves class FXWrapper to package

### DIFF
--- a/platform-examples/process-monitor-sample/process-monitor-client-javafx/src/main/java/com/canoo/dolphin/samples/processmonitor/ProcessMonitorView.java
+++ b/platform-examples/process-monitor-sample/process-monitor-client-javafx/src/main/java/com/canoo/dolphin/samples/processmonitor/ProcessMonitorView.java
@@ -17,7 +17,7 @@ package com.canoo.dolphin.samples.processmonitor;
 
 import com.canoo.platform.remoting.client.ClientContext;
 import com.canoo.platform.remoting.client.javafx.FXBinder;
-import com.canoo.platform.remoting.client.javafx.binding.FXWrapper;
+import com.canoo.platform.remoting.client.javafx.FXWrapper;
 import com.canoo.platform.remoting.client.javafx.view.AbstractViewController;
 import com.canoo.dolphin.samples.processmonitor.model.ProcessBean;
 import com.canoo.dolphin.samples.processmonitor.model.ProcessListBean;

--- a/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/FXWrapper.java
+++ b/platform/dolphin-platform-remoting-client-javafx/src/main/java/com/canoo/platform/remoting/client/javafx/FXWrapper.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.canoo.platform.remoting.client.javafx.binding;
+package com.canoo.platform.remoting.client.javafx;
 
 import com.canoo.platform.remoting.client.javafx.FXBinder;
 import com.canoo.platform.remoting.ListChangeEvent;


### PR DESCRIPTION
Moves class FXWrapper to package com.canoo.platform.remoting.client.javafx, 
because it was in the wrong package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/677)
<!-- Reviewable:end -->
