### PR TITLE
Adding convenience methods from JavaFX's ObservableList

### DIFF
--- a/platform/dolphin-platform-remoting-common/src/main/java/com/canoo/dp/impl/remoting/collections/ObservableArrayList.java
+++ b/platform/dolphin-platform-remoting-common/src/main/java/com/canoo/dp/impl/remoting/collections/ObservableArrayList.java
@@ -178,6 +178,11 @@ public class ObservableArrayList<E> implements ObservableList<E> {
         return batchRemove(c, false);
     }
 
+    @Override
+    public boolean retainAll(E... elements) {
+        return batchRemove(Arrays.asList(E), false);
+    }
+
     private boolean batchRemove(final Collection<?> c, boolean isRemove){
         if (null != c && c.isEmpty()) {
             return false;
@@ -237,6 +242,15 @@ public class ObservableArrayList<E> implements ObservableList<E> {
         final E oldElement = list.remove(index);
         fireListChanged(new ListChangeEventImpl<>(this, index, index, Collections.singletonList(oldElement)));
         return oldElement;
+    }
+
+    @Override
+    public void remove(int from, int to)
+    {
+        final List<E> oldList = list.subList(from, to);
+        final List<E> copy = new ArrayList<>(oldList);
+        oldList.clear();
+        fireListChanged(new ListChangeEventImpl<>(this, from, to, Collections.unmodifiableList(copy)));
     }
 
     @Override

--- a/platform/dolphin-platform-remoting-common/src/main/java/com/canoo/dp/impl/remoting/collections/ObservableArrayList.java
+++ b/platform/dolphin-platform-remoting-common/src/main/java/com/canoo/dp/impl/remoting/collections/ObservableArrayList.java
@@ -180,7 +180,7 @@ public class ObservableArrayList<E> implements ObservableList<E> {
 
     @Override
     public boolean retainAll(E... elements) {
-        return batchRemove(Arrays.asList(E), false);
+        return batchRemove(Arrays.asList(elements), false);
     }
 
     private boolean batchRemove(final Collection<?> c, boolean isRemove){

--- a/platform/dolphin-platform-remoting-common/src/main/java/com/canoo/platform/remoting/ObservableList.java
+++ b/platform/dolphin-platform-remoting-common/src/main/java/com/canoo/platform/remoting/ObservableList.java
@@ -25,7 +25,7 @@ import java.util.List;
  * By adding a {@link ListChangeListener} (see {@link #onChanged(ListChangeListener)}) all mutations of the list can be observed.
  * In addition this class provides some convenience methods.
  * <p>
- * The {@link ObservableList} interface is part of teh Dolphin Platform model API. Since the lifecylce of models will be
+ * The {@link ObservableList} interface is part of the Dolphin Platform model API. Since the lifecylce of models will be
  * managed by the Dolphin Platform the API don't provide a public implementation for this interface. When defining models
  * a developer only need to use the interface like it is already descriped in the {@link Property}
  * class.
@@ -95,4 +95,20 @@ public interface ObservableList<E> extends List<E> {
      * @return <tt>true</tt> if the list changed as a result of the call
      */
     boolean removeAll(E... elements);
+
+    /**
+     * A convenient mrethod for var-arg usage of retain method.
+     * @param elements the elements to be retained
+     * @return <tt>true</tt> if list changed as a result of the call
+     */
+    boolean retainAll(E... elements);
+
+    /**
+     * Removes all elements from the list from {@param from} inclusive up to {@param to} exclusive;
+     * Essentially a convenience method for sublist(from, to).clear()
+     * @param from the start of the range to remove (inclusive)
+     * @param to the end of the range to remove (exclusive)
+     * @throws IndexOutofBoundsException if an illegal range is provided
+     */
+    void remove(int from, int to);
 }

--- a/platform/dolphin-platform-remoting-common/src/main/java/com/canoo/platform/remoting/ObservableList.java
+++ b/platform/dolphin-platform-remoting-common/src/main/java/com/canoo/platform/remoting/ObservableList.java
@@ -97,7 +97,7 @@ public interface ObservableList<E> extends List<E> {
     boolean removeAll(E... elements);
 
     /**
-     * A convenient mrethod for var-arg usage of retain method.
+     * A var-arg convenience method for the retain method
      * @param elements the elements to be retained
      * @return <tt>true</tt> if list changed as a result of the call
      */

--- a/platform/dolphin-platform-remoting-common/src/test/java/com/canoo/dolphin/impl/collections/TestObservableArrayList.java
+++ b/platform/dolphin-platform-remoting-common/src/test/java/com/canoo/dolphin/impl/collections/TestObservableArrayList.java
@@ -186,7 +186,7 @@ public class TestObservableArrayList {
         
         list.remove(1, 5);
         Assert.assertFalse(list.isEmpty());
-        Assert.assertEquals(list.size(), 5);
+        Assert.assertEquals(list.size(), 6);
         assertSameContent(list, Arrays.asList("1", "6", "7" ,"8" , "9", "10"));
         list.clear();
     }

--- a/platform/dolphin-platform-remoting-common/src/test/java/com/canoo/dolphin/impl/collections/TestObservableArrayList.java
+++ b/platform/dolphin-platform-remoting-common/src/test/java/com/canoo/dolphin/impl/collections/TestObservableArrayList.java
@@ -161,6 +161,34 @@ public class TestObservableArrayList {
         assertSameContent(list, Arrays.asList("1", "2", "3", "4", "5"));
         list.clear();
 
+        list.addAll("1", "2", "3", "4", "5", "6", "7" ,"8" , "9", "10");
+        Assert.assertFalse(list.isEmpty());
+        Assert.assertEquals(list.size(), 10);
+
+        list.retainAll("1", "2", "3", "4", "5");
+        Assert.assertFalse(list.isEmpty());
+        Assert.assertEquals(list.size(), 5);
+        assertSameContent(list, Arrays.asList("1", "2", "3", "4", "5"));
+        list.clear();
+
+    }
+
+    @Test
+    public void testRemoveRange() {
+        final ObservableArrayList<String> list = new ObservableArrayList<>();
+        
+        Assert.assertTrue(list.isEmpty());
+        Assert.assertEquals(list.size(), 0);
+        
+        list.addAll("1", "2", "3", "4", "5", "6", "7" ,"8" , "9", "10");
+        Assert.assertFalse(list.isEmpty());
+        Assert.assertEquals(list.size(), 10);
+        
+        list.remove(1, 5);
+        Assert.assertFalse(list.isEmpty());
+        Assert.assertEquals(list.size(), 5);
+        assertSameContent(list, Arrays.asList("1", "6", "7" ,"8" , "9", "10"));
+        list.clear();
     }
 
     private <T> void assertSameContent(List<T> a, List<T> b) {


### PR DESCRIPTION
In particular, added the retainAll vararg overload, and the remove(int
from, int to) overload method.

It wasn't clear that the other additional methods were useful (they return other JavaFX classes which don't seem to have dolphin equivalents) or they were already implemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/682)
<!-- Reviewable:end -->
