### PR TITLE
Configure javadoc task to copy resources. Fixes #299

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,17 @@ subprojects { subprj ->
                              'https://canoo.github.io/dolphin-platform/javadoc/server/',
                              'https://canoo.github.io/dolphin-platform/javadoc/server-spring/',
                              'https://canoo.github.io/dolphin-platform/javadoc/server-jee/']
+
+            if (subprj.file('src/main/javadoc/overview.html').exists()) {
+                options.overview = file('src/main/javadoc/overview.html')
+            }
+            doLast {
+                copy {
+                    from file('src/main/javadoc')
+                    into javadoc.destinationDir
+                    include '**/doc-files/*'
+                }
+            }
         }
 
         task sourcesJar(type: Jar) {
@@ -157,7 +168,6 @@ subprojects { subprj ->
             testCompile "org.jmockit:jmockit:$jmockitVersion"
         }
     }
-
 }
 
 evaluationDependsOnChildren()


### PR DESCRIPTION
Pending: review all included paths in source code as there may be mistakes. For example, `com.canoo.platform.remoting.client.ControllerProxy` in project `dolphin-platform-remoting-client` expects a path resolved to `com/canoo/platform/remoting/client/doc-files/proxy.png` but is currently defined as `com/canoo/dolphin/client/doc-files/proxy.png`. This review is outside of the scope for this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/813)
<!-- Reviewable:end -->
