### PR TITLE
Login endpoint on server

### DIFF
--- a/platform-extras/dolphin-platform-security-client/src/main/java/com/canoo/dp/impl/security/KeycloakSecurity.java
+++ b/platform-extras/dolphin-platform-security-client/src/main/java/com/canoo/dp/impl/security/KeycloakSecurity.java
@@ -19,6 +19,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import static com.canoo.dp.impl.platform.core.http.HttpHeaderConstants.CONTENT_TYPE_HEADER;
+import static com.canoo.dp.impl.platform.core.http.HttpHeaderConstants.FORM_MIME_TYPE;
 import static com.canoo.dp.impl.platform.core.http.HttpStatus.SC_HTTP_UNAUTHORIZED;
 import static com.canoo.dp.impl.security.SecurityConfiguration.APPLICATION_PROPERTY_DEFAULT_VALUE;
 import static com.canoo.dp.impl.security.SecurityConfiguration.APPLICATION_PROPERTY_NAME;
@@ -55,7 +57,7 @@ public class KeycloakSecurity implements Security {
     public KeycloakSecurity(final ClientConfiguration configuration) {
         Assert.requireNonNull(configuration, "configuration");
 
-        this.appName =configuration.getProperty(APPLICATION_PROPERTY_NAME, APPLICATION_PROPERTY_DEFAULT_VALUE);
+        this.appName = configuration.getProperty(APPLICATION_PROPERTY_NAME, APPLICATION_PROPERTY_DEFAULT_VALUE);
         Assert.requireNonBlank(appName, "appName");
 
         this.authEndpoint = configuration.getProperty(AUTH_ENDPOINT_PROPERTY_NAME, AUTH_ENDPOINT_PROPERTY_DEFAULT_VALUE);
@@ -97,7 +99,7 @@ public class KeycloakSecurity implements Security {
         Assert.requireNonNull(content, "content");
         LOG.debug("receiving new token from keycloak server");
         final HttpClientConnection clientConnection = createConnection();
-        clientConnection.addRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+        clientConnection.addRequestHeader(CONTENT_TYPE_HEADER, FORM_MIME_TYPE);
         clientConnection.setDoOutput(true);
         clientConnection.writeRequestContent(content);
         final int responseCode = clientConnection.readResponseCode();

--- a/platform-extras/dolphin-platform-security-client/src/main/java/com/canoo/dp/impl/security/SecurityProvider.java
+++ b/platform-extras/dolphin-platform-security-client/src/main/java/com/canoo/dp/impl/security/SecurityProvider.java
@@ -24,11 +24,8 @@ public class SecurityProvider extends AbstractServiceProvider<Security> {
     @Override
     protected Security createService(final ClientConfiguration configuration) {
         Assert.requireNonNull(configuration, "configuration");
-        
-        final String authEndpoint = configuration.getProperty(AUTH_ENDPOINT_PROPERTY_NAME, AUTH_ENDPOINT_PROPERTY_DEFAULT_VALUE);
-        final String realmName = configuration.getProperty(REALM_PROPERTY_NAME, REALM_PROPERTY_DEFAULT_VALUE);
-        final String appName = configuration.getProperty(APPLICATION_PROPERTY_NAME, APPLICATION_PROPERTY_DEFAULT_VALUE);
 
-        return new KeycloakSecurity(authEndpoint, realmName, appName, configuration.getBackgroundExecutor());
+
+        return new KeycloakSecurity(configuration);
     }
 }

--- a/platform-extras/dolphin-platform-security-common/src/main/java/com/canoo/dp/impl/security/SecurityConfiguration.java
+++ b/platform-extras/dolphin-platform-security-common/src/main/java/com/canoo/dp/impl/security/SecurityConfiguration.java
@@ -15,5 +15,9 @@ public interface SecurityConfiguration {
 
     String APPLICATION_PROPERTY_NAME = "security.keycloak.app";
 
+    String DIRECT_CONNECTION_PROPERTY_NAME = "security.useDirectConnection";
+
+    boolean DIRECT_CONNECTION_PROPERTY_DEFAULT_VALUE = false;
+
     String APPLICATION_PROPERTY_DEFAULT_VALUE = "myApp";
 }

--- a/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/KeycloakConfiguration.java
+++ b/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/KeycloakConfiguration.java
@@ -30,6 +30,7 @@ public class KeycloakConfiguration implements Serializable {
 
     public final static String LOGIN_ENDPOINTS_PROPERTY_NAME = "security.loginEndpoint";
 
+    public final static String LOGIN_ENDPOINTS_PROPERTY_DEFAULT_VALUE = "/openid-connect";
 
     public final static String SECURE_ENDPOINTS_PROPERTY_DEFAULT_VALUE = "/dolphin";
 
@@ -56,7 +57,7 @@ public class KeycloakConfiguration implements Serializable {
         this.secureEndpoints.addAll(platformConfiguration.getListProperty(SECURE_ENDPOINTS_PROPERTY_NAME, Collections.emptyList()));
         this.securityActive = platformConfiguration.getBooleanProperty(SECURITY_ACTIVE_PROPERTY_NAME, false);
         this.loginEndpointActive = platformConfiguration.getBooleanProperty(LOGIN_ENDPOINTS_ACTIVE_PROPERTY_NAME, true);
-        this.loginEndpoint = platformConfiguration.getProperty(LOGIN_ENDPOINTS_PROPERTY_NAME, "/login");
+        this.loginEndpoint = platformConfiguration.getProperty(LOGIN_ENDPOINTS_PROPERTY_NAME, LOGIN_ENDPOINTS_PROPERTY_DEFAULT_VALUE);
 
     }
 

--- a/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/KeycloakConfiguration.java
+++ b/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/KeycloakConfiguration.java
@@ -26,15 +26,25 @@ public class KeycloakConfiguration implements Serializable {
 
     public final static String SECURE_ENDPOINTS_PROPERTY_NAME = "security.endpoints";
 
+    public final static String LOGIN_ENDPOINTS_ACTIVE_PROPERTY_NAME = "security.loginEndpoint.active";
+
+    public final static String LOGIN_ENDPOINTS_PROPERTY_NAME = "security.loginEndpoint";
+
+
     public final static String SECURE_ENDPOINTS_PROPERTY_DEFAULT_VALUE = "/dolphin";
 
     private final String realmName;
 
     private final boolean securityActive;
 
+    private final boolean loginEndpointActive;
+
+
     private final String applicationName;
 
     private final String authEndpoint;
+
+    private final String loginEndpoint;
 
     private final List<String> secureEndpoints = new ArrayList<>();
 
@@ -45,6 +55,9 @@ public class KeycloakConfiguration implements Serializable {
         this.authEndpoint = platformConfiguration.getProperty(AUTH_ENDPOINT_PROPERTY_NAME, AUTH_ENDPOINT_PROPERTY_DEFAULT_VALUE) + "/auth";
         this.secureEndpoints.addAll(platformConfiguration.getListProperty(SECURE_ENDPOINTS_PROPERTY_NAME, Collections.emptyList()));
         this.securityActive = platformConfiguration.getBooleanProperty(SECURITY_ACTIVE_PROPERTY_NAME, false);
+        this.loginEndpointActive = platformConfiguration.getBooleanProperty(LOGIN_ENDPOINTS_ACTIVE_PROPERTY_NAME, true);
+        this.loginEndpoint = platformConfiguration.getProperty(LOGIN_ENDPOINTS_PROPERTY_NAME, "/login");
+
     }
 
     public String getRealmName() {
@@ -75,5 +88,13 @@ public class KeycloakConfiguration implements Serializable {
 
     public boolean isSecurityActive() {
         return securityActive;
+    }
+
+    public boolean isLoginEndpointActive() {
+        return loginEndpointActive;
+    }
+
+    public String getLoginEndpoint() {
+        return loginEndpoint;
     }
 }

--- a/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/KeycloakTokenServlet.java
+++ b/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/KeycloakTokenServlet.java
@@ -43,7 +43,7 @@ public class KeycloakTokenServlet extends HttpServlet {
             }
             final byte[] responseContent = clientConnection.readResponseContent();
             ConnectionUtils.writeContent(resp.getOutputStream(), responseContent);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             resp.sendError(SC_HTTP_UNAUTHORIZED, "Can not authorize");
         }
     }

--- a/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/LoginServlet.java
+++ b/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/LoginServlet.java
@@ -1,0 +1,57 @@
+package com.canoo.dp.impl.server.security;
+
+import com.canoo.dp.impl.platform.core.Assert;
+import com.canoo.dp.impl.platform.core.http.ConnectionUtils;
+import com.canoo.dp.impl.platform.core.http.DefaultHttpURLConnectionFactory;
+import com.canoo.platform.core.DolphinRuntimeException;
+import com.canoo.platform.core.http.RequestMethod;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.Optional;
+
+import static com.canoo.dp.impl.security.SecurityHttpHeader.REALM_NAME_HEADER;
+
+public class LoginServlet extends HttpServlet {
+
+    private final KeycloakConfiguration configuration;
+
+    public LoginServlet(final KeycloakConfiguration configuration) {
+        this.configuration = Assert.requireNonNull(configuration, "configuration");
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            final String realmName = Optional.ofNullable(req.getHeader(REALM_NAME_HEADER)).orElse(configuration.getRealmName());
+            final String authEndPoint = configuration.getAuthEndpoint();
+            final byte[] content = ConnectionUtils.readContent(req.getInputStream());
+
+            final URI url = new URI(authEndPoint + "/auth/realms/" + realmName + "/protocol/openid-connect/token");
+            final HttpURLConnection connection = new DefaultHttpURLConnectionFactory().create(url);
+            connection.setRequestMethod(RequestMethod.POST.getRawName());
+            connection.setRequestProperty("charset", "UTF-8");
+            connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+            connection.setRequestProperty("Content-Length", content.length + "");
+            connection.setDoOutput(true);
+            connection.setDoInput(true);
+            ConnectionUtils.writeContent(connection, content);
+
+            final int responseCode = connection.getResponseCode();
+            if (responseCode == 401) {
+                throw new DolphinRuntimeException("Invalid login!");
+            }
+
+            final byte[] responseContent = ConnectionUtils.readContent(connection);
+
+            ConnectionUtils.writeContent(resp.getOutputStream(), responseContent);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/SecurityModule.java
+++ b/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/SecurityModule.java
@@ -33,7 +33,7 @@ public class SecurityModule extends AbstractBaseModule {
 
         if(configuration.isLoginEndpointActive()) {
             final ServletContext servletContext = coreComponents.getInstance(ServletContext.class);
-            servletContext.addServlet("security-login", new LoginServlet(configuration)).addMapping(configuration.getLoginEndpoint());
+            servletContext.addServlet("security-login", new KeycloakTokenServlet(configuration)).addMapping(configuration.getLoginEndpoint());
         }
     }
 

--- a/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/SecurityModule.java
+++ b/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/SecurityModule.java
@@ -30,6 +30,11 @@ public class SecurityModule extends AbstractBaseModule {
         final KeycloakConfiguration configuration = new KeycloakConfiguration(coreComponents.getConfiguration());
         final DolphinSecurityBootstrap bootstrap = DolphinSecurityBootstrap.getInstance();
         bootstrap.init(coreComponents.getInstance(ServletContext.class), coreComponents.getConfiguration());
+
+        if(configuration.isLoginEndpointActive()) {
+            final ServletContext servletContext = coreComponents.getInstance(ServletContext.class);
+            servletContext.addServlet("security-login", new LoginServlet(configuration)).addMapping(configuration.getLoginEndpoint());
+        }
     }
 
     @Override

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dp/impl/platform/client/http/HttpCallExecutorImpl.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dp/impl/platform/client/http/HttpCallExecutorImpl.java
@@ -2,7 +2,7 @@ package com.canoo.dp.impl.platform.client.http;
 
 import com.canoo.dp.impl.platform.core.Assert;
 import com.canoo.platform.client.ClientConfiguration;
-import com.canoo.platform.core.functional.ExecutablePromise;
+import com.canoo.platform.core.functional.Promise;
 import com.canoo.platform.core.http.BadResponseException;
 import com.canoo.platform.core.http.HttpException;
 import com.canoo.platform.core.http.HttpResponse;
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 @API(since = "0.x", status = INTERNAL)
-public class HttpCallExecutorImpl<R> implements ExecutablePromise<HttpResponse<R>, HttpException> {
+public class HttpCallExecutorImpl<R> implements Promise<HttpResponse<R>, HttpException> {
 
     private final ExecutorService executor;
 

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dp/impl/platform/client/http/HttpCallRequestBuilderImpl.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dp/impl/platform/client/http/HttpCallRequestBuilderImpl.java
@@ -1,6 +1,8 @@
 package com.canoo.dp.impl.platform.client.http;
 
 import com.canoo.dp.impl.platform.core.Assert;
+import com.canoo.dp.impl.platform.core.http.HttpClientConnection;
+import com.canoo.dp.impl.platform.core.http.HttpHeaderImpl;
 import com.canoo.platform.client.ClientConfiguration;
 import com.canoo.platform.core.DolphinRuntimeException;
 import com.canoo.platform.core.http.ByteArrayProvider;
@@ -14,7 +16,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.canoo.dp.impl.platform.core.http.HttpHeaderConstants.CONTENT_LENGHT_HEADER;
 import static com.canoo.dp.impl.platform.core.http.HttpHeaderConstants.CONTENT_TYPE_HEADER;
 import static com.canoo.dp.impl.platform.core.http.HttpHeaderConstants.JSON_MIME_TYPE;
 import static org.apiguardian.api.API.Status.INTERNAL;
@@ -56,8 +57,6 @@ public class HttpCallRequestBuilderImpl implements HttpCallRequestBuilder {
     @Override
     public HttpCallResponseBuilder withContent(final byte[] content, final String contentType) {
         withHeader(CONTENT_TYPE_HEADER, contentType);
-        withHeader(CONTENT_LENGHT_HEADER, content.length + "");
-
         connection.setDoOutput(true);
         return continueWithResponseBuilder(() -> content);
     }

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dp/impl/platform/client/http/HttpCallResponseBuilderImpl.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dp/impl/platform/client/http/HttpCallResponseBuilderImpl.java
@@ -1,9 +1,10 @@
 package com.canoo.dp.impl.platform.client.http;
 
 import com.canoo.dp.impl.platform.core.Assert;
+import com.canoo.dp.impl.platform.core.http.HttpClientConnection;
+import com.canoo.dp.impl.platform.core.http.HttpHeaderImpl;
 import com.canoo.platform.client.ClientConfiguration;
 import com.canoo.platform.core.DolphinRuntimeException;
-import com.canoo.platform.core.functional.ExecutablePromise;
 import com.canoo.platform.core.functional.Promise;
 import com.canoo.platform.core.http.ByteArrayProvider;
 import com.canoo.platform.core.http.ConnectionException;

--- a/platform/dolphin-platform-client/src/main/java/com/canoo/dp/impl/platform/client/http/HttpClientImpl.java
+++ b/platform/dolphin-platform-client/src/main/java/com/canoo/dp/impl/platform/client/http/HttpClientImpl.java
@@ -2,6 +2,7 @@ package com.canoo.dp.impl.platform.client.http;
 
 import com.canoo.dp.impl.platform.core.Assert;
 import com.canoo.dp.impl.platform.core.http.DefaultHttpURLConnectionFactory;
+import com.canoo.dp.impl.platform.core.http.HttpClientConnection;
 import com.canoo.platform.client.ClientConfiguration;
 import com.canoo.platform.core.http.HttpClient;
 import com.canoo.platform.core.http.HttpCallRequestBuilder;

--- a/platform/dolphin-platform-client/src/test/java/com/canoo/dp/impl/platform/client/http/HttpClientTests.java
+++ b/platform/dolphin-platform-client/src/test/java/com/canoo/dp/impl/platform/client/http/HttpClientTests.java
@@ -48,7 +48,6 @@ public class HttpClientTests {
     @BeforeClass
     public void startSpark() {
         Spark.port(freePort);
-        Spark.threadPool(100, 1_000, 10);
         Spark.get("/", (req, res) -> "Spark Server for HTTP client integration tests");
         Spark.get("/error", (req, res) -> {
             res.status(401);
@@ -246,7 +245,7 @@ public class HttpClientTests {
                 .execute();
 
         //then:
-        final HttpResponse<String> response = future.get(1_000, TimeUnit.MILLISECONDS);
+        final HttpResponse<String> response = future.get(100_000, TimeUnit.MILLISECONDS);
         assertThat("response not defined", response, notNullValue());
         assertThat("Wrong response code", response.getStatusCode(), is(200));
         assertThat("Content should not be null", response.getRawContent(), notNullValue());

--- a/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/ConnectionUtils.java
+++ b/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/ConnectionUtils.java
@@ -27,15 +27,18 @@ public class ConnectionUtils {
 
     public static byte[] readContent(final HttpURLConnection connection) throws IOException {
         Assert.requireNonNull(connection, "connection");
-        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        try(final InputStream is = connection.getInputStream()) {
-            int read = is.read();
-            while (read != -1) {
-                byteArrayOutputStream.write(read);
-                read = is.read();
+        final InputStream errorstream = connection.getErrorStream();
+        if(errorstream == null) {
+            try (final InputStream inputStream = connection.getInputStream()) {
+                return readContent(inputStream);
+            }
+        } else {
+            try {
+                return readContent(errorstream);
+            } finally {
+                errorstream.close();
             }
         }
-        return byteArrayOutputStream.toByteArray();
     }
 
     public static String readUTF8Content(final HttpURLConnection connection) throws IOException {

--- a/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/ConnectionUtils.java
+++ b/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/ConnectionUtils.java
@@ -16,6 +16,7 @@ public class ConnectionUtils {
     private ConnectionUtils() {}
 
     public static byte[] readContent(final InputStream inputStream) throws IOException {
+        Assert.requireNonNull(inputStream, "inputStream");
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         int read = inputStream.read();
             while (read != -1) {

--- a/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/ConnectionUtils.java
+++ b/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/ConnectionUtils.java
@@ -1,0 +1,82 @@
+package com.canoo.dp.impl.platform.core.http;
+
+import com.canoo.dp.impl.platform.core.Assert;
+import com.canoo.platform.core.http.ByteArrayProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+
+import static com.canoo.dp.impl.platform.core.http.HttpHeaderConstants.CHARSET;
+
+public class ConnectionUtils {
+
+    private ConnectionUtils() {}
+
+    public static byte[] readContent(final InputStream inputStream) throws IOException {
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        int read = inputStream.read();
+            while (read != -1) {
+                byteArrayOutputStream.write(read);
+                read = inputStream.read();
+            }
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    public static byte[] readContent(final HttpURLConnection connection) throws IOException {
+        Assert.requireNonNull(connection, "connection");
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try(final InputStream is = connection.getInputStream()) {
+            int read = is.read();
+            while (read != -1) {
+                byteArrayOutputStream.write(read);
+                read = is.read();
+            }
+        }
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    public static String readUTF8Content(final HttpURLConnection connection) throws IOException {
+        return new String(readContent(connection), CHARSET);
+    }
+
+    public static String readUTF8Content(final InputStream inputStream) throws IOException {
+        return new String(readContent(inputStream), CHARSET);
+    }
+
+    public static void writeContent(final OutputStream outputStream, final byte[] rawData) throws IOException {
+        Assert.requireNonNull(outputStream, "outputStream");
+        Assert.requireNonNull(rawData, "rawData");
+        outputStream.write(rawData);
+    }
+
+    public static void writeContent(final HttpURLConnection connection, final byte[] rawData) throws IOException {
+        Assert.requireNonNull(connection, "connection");
+        Assert.requireNonNull(rawData, "rawData");
+        try(final OutputStream outputStream = connection.getOutputStream()) {
+            writeContent(outputStream, rawData);
+        }
+    }
+
+    public static void writeContent(final HttpURLConnection connection, final ByteArrayProvider provider) throws IOException {
+        Assert.requireNonNull(provider, "provider");
+        writeContent(connection, provider.get());
+    }
+
+    public static void writeContent(final OutputStream outputStream, final ByteArrayProvider provider) throws IOException {
+        Assert.requireNonNull(provider, "provider");
+        writeContent(outputStream, provider.get());
+    }
+
+    public static void writeUTF8Content(final HttpURLConnection connection, final String content) throws IOException {
+        Assert.requireNonNull(content, "content");
+        writeContent(connection, content.getBytes(CHARSET));
+    }
+
+    public static void writeUTF8Content(final OutputStream outputStream, final String content) throws IOException {
+        Assert.requireNonNull(content, "content");
+        writeContent(outputStream, content.getBytes(CHARSET));
+    }
+}

--- a/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/HttpClientConnection.java
+++ b/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/HttpClientConnection.java
@@ -1,4 +1,4 @@
-package com.canoo.dp.impl.platform.client.http;
+package com.canoo.dp.impl.platform.core.http;
 
 import com.canoo.dp.impl.platform.core.Assert;
 import com.canoo.platform.core.http.HttpHeader;
@@ -7,15 +7,16 @@ import com.canoo.platform.core.http.RequestMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.canoo.dp.impl.platform.core.http.HttpHeaderConstants.CHARSET;
+import static com.canoo.dp.impl.platform.core.http.HttpHeaderConstants.CHARSET_HEADER;
+import static com.canoo.dp.impl.platform.core.http.HttpHeaderConstants.CONTENT_LENGHT_HEADER;
 import static com.canoo.platform.core.http.RequestMethod.GET;
 
 public class HttpClientConnection {
@@ -41,9 +42,23 @@ public class HttpClientConnection {
         connection.setUseCaches(false);
     }
 
+    public HttpClientConnection(final URI url, final RequestMethod method) throws IOException {
+        this(new DefaultHttpURLConnectionFactory(), url, method);
+    }
+
+    public void addRequestHeader(final String name, final String content) {
+        addRequestHeader(new HttpHeaderImpl(name, content));
+    }
+
     public void addRequestHeader(final HttpHeader headers) {
         Assert.requireNonNull(headers, "headers");
         connection.setRequestProperty(headers.getName(), headers.getContent());
+    }
+
+    public void writeRequestContent(final String content) throws IOException {
+        Assert.requireNonNull(content, "content");
+        writeRequestContent(content.getBytes(CHARSET));
+        addRequestHeader(CHARSET_HEADER, CHARSET);
     }
 
     public void writeRequestContent(final byte[] content) throws IOException {
@@ -53,9 +68,8 @@ public class HttpClientConnection {
                 LOG.warn("You are currently defining a request content for a HTTP GET call for endpoint '{}'", url);
             }
             setDoOutput(true);
-            try (final OutputStream w = connection.getOutputStream()) {
-                w.write(content);
-            }
+            addRequestHeader(CONTENT_LENGHT_HEADER, content.length + "");
+            ConnectionUtils.writeContent(connection, content);
         }
     }
 
@@ -64,35 +78,24 @@ public class HttpClientConnection {
     }
 
     public byte[] readResponseContent() throws IOException {
-        final InputStream errorstream = connection.getErrorStream();
+        return ConnectionUtils.readContent(connection);
+    }
 
-        if(errorstream == null) {
-            try (final InputStream inputStream = connection.getInputStream()) {
-                try (final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
-                    int read = inputStream.read();
-                    while (read != -1) {
-                        byteArrayOutputStream.write(read);
-                        read = inputStream.read();
-                    }
-                    return byteArrayOutputStream.toByteArray();
-                }
-            }
-        } else {
-            try (final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
-                int read = errorstream.read();
-                while (read != -1) {
-                    byteArrayOutputStream.write(read);
-                    read = errorstream.read();
-                }
-                return byteArrayOutputStream.toByteArray();
-            } finally {
-                errorstream.close();
-            }
-        }
+    public String readUTFResponseContent() throws IOException {
+        final String charSet = Optional.ofNullable(getResponseHeader(CHARSET_HEADER)).map(h -> h.getContent()).orElse(CHARSET);
+        return new String(readResponseContent(), charSet);
     }
 
     public String getResponseMessage() throws IOException {
         return connection.getResponseMessage();
+    }
+
+    public HttpHeader getResponseHeader(final String name) {
+        return getResponseHeaders().stream()
+                .filter(h -> h.getName() != null)
+                .filter(h -> h.getName().equals(name))
+                .findFirst()
+                .orElse(null);
     }
 
     public List<HttpHeader> getResponseHeaders() {

--- a/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/HttpHeaderConstants.java
+++ b/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/HttpHeaderConstants.java
@@ -6,6 +6,8 @@ public interface HttpHeaderConstants {
 
     String CONTENT_TYPE_HEADER = "Content-Type";
 
+    String CHARSET_HEADER = "charset";
+
     String CONTENT_LENGHT_HEADER = "Content-Length";
 
     String ACCEPT_HEADER = "Accept";

--- a/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/HttpHeaderConstants.java
+++ b/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/HttpHeaderConstants.java
@@ -23,4 +23,6 @@ public interface HttpHeaderConstants {
     String TEXT_MIME_TYPE = "application/txt;charset=utf-8";
 
     String RAW_MIME_TYPE = "application/raw";
+
+    String FORM_MIME_TYPE = "application/x-www-form-urlencoded";
 }

--- a/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/HttpHeaderImpl.java
+++ b/platform/dolphin-platform-core/src/main/java/com/canoo/dp/impl/platform/core/http/HttpHeaderImpl.java
@@ -1,4 +1,4 @@
-package com.canoo.dp.impl.platform.client.http;
+package com.canoo.dp.impl.platform.core.http;
 
 import com.canoo.platform.core.http.HttpHeader;
 
@@ -22,5 +22,10 @@ public class HttpHeaderImpl implements HttpHeader {
     @Override
     public String getContent() {
         return content;
+    }
+
+    @Override
+    public String toString() {
+        return name + ":" + content;
     }
 }

--- a/platform/dolphin-platform-core/src/main/java/com/canoo/platform/core/functional/ExecutablePromise.java
+++ b/platform/dolphin-platform-core/src/main/java/com/canoo/platform/core/functional/ExecutablePromise.java
@@ -1,8 +1,0 @@
-package com.canoo.platform.core.functional;
-
-import java.util.concurrent.CompletableFuture;
-
-public interface ExecutablePromise<V, T extends Throwable> extends Promise<V, T> {
-
-    CompletableFuture<V> execute();
-}


### PR DESCRIPTION
Provides a login endpoint on the server (servlet based) in the security module.
The endpoint is a proxy to the Keycloak server that can be used for login and token refresh. By doing so the client do not need to know / access the KeyCloak server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/819)
<!-- Reviewable:end -->
