### PR TITLE
Define keycloak realm at login

### DIFF
--- a/platform-extras/dolphin-platform-security-client/src/main/java/com/canoo/platform/client/security/Security.java
+++ b/platform-extras/dolphin-platform-security-client/src/main/java/com/canoo/platform/client/security/Security.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 @API(since = "0.19.0", status = API.Status.EXPERIMENTAL)
 public interface Security {
 
-    Future<Void> login(String user, String password);
+    Future<Void> login(String user, String password, String... args);
 
     Future<Void> logout();
 

--- a/platform-extras/dolphin-platform-security-common/src/main/java/com/canoo/dp/impl/security/SecurityConfiguration.java
+++ b/platform-extras/dolphin-platform-security-common/src/main/java/com/canoo/dp/impl/security/SecurityConfiguration.java
@@ -26,9 +26,13 @@ public interface SecurityConfiguration {
 
     String REALM_PROPERTY_NAME = "security.keycloak.realm";
 
+    String ALLOWED_REALMS_PROPERTY_NAME = "security.keycloak.allowedRealms";
+
     String REALM_PROPERTY_DEFAULT_VALUE = "myRealm";
 
     String APPLICATION_PROPERTY_NAME = "security.keycloak.app";
+
+    String ALLOWED_APPLICATIONS_PROPERTY_NAME = "security.keycloak.allowedApplications";
 
     String DIRECT_CONNECTION_PROPERTY_NAME = "security.useDirectConnection";
 

--- a/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/DolphinKeycloakConfigResolver.java
+++ b/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/DolphinKeycloakConfigResolver.java
@@ -51,23 +51,24 @@ public class DolphinKeycloakConfigResolver implements KeycloakConfigResolver {
         Optional.ofNullable(authEndPoint).orElseThrow(() -> new SecurityException("Auth endpoint for security check is not configured!"));
 
         final AdapterConfig adapterConfig = new AdapterConfig();
-        if(isRealmAllowed(realmName)){
+
+        if(configuration.isRealmAllowed(realmName)){
             adapterConfig.setRealm(realmName);
         }else{
-            throw new SecurityException("Access Denied! The given realm is not in the allowed realms.");
+            throw new SecurityException("Access Denied! The given realm is not allowed.");
+        }
+        if(configuration.isApplicationAllowed(applicationName)){
+            adapterConfig.setResource(applicationName);
+        }else{
+            throw new SecurityException("Access Denied! The given application is not allowed.");
         }
 
-        adapterConfig.setResource(applicationName);
         adapterConfig.setAuthServerUrl(authEndPoint);
         Optional.ofNullable(request.getHeader(BEARER_ONLY_HEADER)).
                 ifPresent(v -> adapterConfig.setBearerOnly(true));
         return KeycloakDeploymentBuilder.build(adapterConfig);
     }
 
-    public static boolean isRealmAllowed(final String realmName){
-        Assert.requireNonNull(realmName, "realmName");
-        return configuration.getRealmNames().contains(realmName);
-    }
     public static void setConfiguration(final KeycloakConfiguration configuration) {
         Assert.requireNonNull(configuration, "configuration");
         DolphinKeycloakConfigResolver.configuration = configuration;

--- a/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/KeycloakConfiguration.java
+++ b/platform-extras/dolphin-platform-security-server/src/main/java/com/canoo/dp/impl/server/security/KeycloakConfiguration.java
@@ -24,11 +24,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.canoo.dp.impl.security.SecurityConfiguration.ALLOWED_APPLICATIONS_PROPERTY_NAME;
+import static com.canoo.dp.impl.security.SecurityConfiguration.ALLOWED_REALMS_PROPERTY_NAME;
 import static com.canoo.dp.impl.security.SecurityConfiguration.APPLICATION_PROPERTY_DEFAULT_VALUE;
 import static com.canoo.dp.impl.security.SecurityConfiguration.APPLICATION_PROPERTY_NAME;
 import static com.canoo.dp.impl.security.SecurityConfiguration.AUTH_ENDPOINT_PROPERTY_DEFAULT_VALUE;
 import static com.canoo.dp.impl.security.SecurityConfiguration.AUTH_ENDPOINT_PROPERTY_NAME;
-import static com.canoo.dp.impl.security.SecurityConfiguration.REALM_PROPERTY_DEFAULT_VALUE;
 import static com.canoo.dp.impl.security.SecurityConfiguration.REALM_PROPERTY_NAME;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
@@ -53,6 +54,8 @@ public class KeycloakConfiguration implements Serializable {
 
     private final List<String> realmNames;
 
+    private final List<String> applicationNames;
+
     private final boolean securityActive;
 
     private final boolean loginEndpointActive;
@@ -68,18 +71,24 @@ public class KeycloakConfiguration implements Serializable {
 
     public KeycloakConfiguration(final PlatformConfiguration platformConfiguration) {
         Assert.requireNonNull(platformConfiguration, "platformConfiguration");
+
         this.realmName = platformConfiguration.getProperty(REALM_PROPERTY_NAME);
-        this.realmNames = platformConfiguration.getListProperty(REALM_PROPERTY_NAME, Collections.emptyList());
+        this.realmNames = platformConfiguration.getListProperty(ALLOWED_REALMS_PROPERTY_NAME, Collections.emptyList());
         if(this.realmName != null && !this.realmName.isEmpty()){
             this.realmNames.add(this.realmName);
         }
+
         this.applicationName = platformConfiguration.getProperty(APPLICATION_PROPERTY_NAME, APPLICATION_PROPERTY_DEFAULT_VALUE) ;
+        this.applicationNames = platformConfiguration.getListProperty(ALLOWED_APPLICATIONS_PROPERTY_NAME, Collections.emptyList());
+        if(this.applicationName != null && !this.applicationName.isEmpty()){
+            this.applicationNames.add(this.applicationName);
+        }
+
         this.authEndpoint = platformConfiguration.getProperty(AUTH_ENDPOINT_PROPERTY_NAME, AUTH_ENDPOINT_PROPERTY_DEFAULT_VALUE) + "/auth";
         this.secureEndpoints.addAll(platformConfiguration.getListProperty(SECURE_ENDPOINTS_PROPERTY_NAME, Collections.emptyList()));
         this.securityActive = platformConfiguration.getBooleanProperty(SECURITY_ACTIVE_PROPERTY_NAME, false);
         this.loginEndpointActive = platformConfiguration.getBooleanProperty(LOGIN_ENDPOINTS_ACTIVE_PROPERTY_NAME, true);
         this.loginEndpoint = platformConfiguration.getProperty(LOGIN_ENDPOINTS_PROPERTY_NAME, LOGIN_ENDPOINTS_PROPERTY_DEFAULT_VALUE);
-
     }
 
     public String getRealmName() {
@@ -122,5 +131,19 @@ public class KeycloakConfiguration implements Serializable {
 
     public String getLoginEndpoint() {
         return loginEndpoint;
+    }
+
+    public List<String> getApplicationNames() {
+        return applicationNames;
+    }
+
+    public boolean isRealmAllowed(final String realmName){
+        Assert.requireNonNull(realmName, "realmName");
+        return getRealmNames().contains(realmName);
+    }
+
+    public boolean isApplicationAllowed(final String applicationName) {
+        Assert.requireNonNull(applicationName, "applicationName");
+        return getApplicationNames().contains(realmName);
     }
 }


### PR DESCRIPTION
A first try of an API to add metadata to the login. Currently supports Keycloak app name and realm name