### PR TITLE
Workaround for delete(from, to)

### DIFF
--- a/platform-integration-tests/integration-common/src/main/java/com/canoo/dolphin/integration/property/ObservableListBean.java
+++ b/platform-integration-tests/integration-common/src/main/java/com/canoo/dolphin/integration/property/ObservableListBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2018 Canoo Engineering AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.canoo.dolphin.integration.property;
+
+import com.canoo.platform.remoting.ObservableList;
+import com.canoo.platform.remoting.Property;
+import com.canoo.platform.remoting.RemotingBean;
+
+@RemotingBean
+public class ObservableListBean {
+
+    private ObservableList<String> list;
+
+    private Property<Boolean> checkResult;
+
+    public ObservableList<String> getList() {
+        return list;
+    }
+
+    public Boolean getCheckResult() {
+        return checkResult.get();
+    }
+
+    public Property<Boolean> checkResultProperty() {
+        return checkResult;
+    }
+
+    public void setCheckResult(final Boolean checkResult) {
+        this.checkResult.set(checkResult);
+    }
+}

--- a/platform-integration-tests/integration-common/src/main/java/com/canoo/dolphin/integration/property/PropertyTestConstants.java
+++ b/platform-integration-tests/integration-common/src/main/java/com/canoo/dolphin/integration/property/PropertyTestConstants.java
@@ -27,10 +27,21 @@ import static com.canoo.dolphin.integration.util.ValueHelper.getUtcZone;
 
 public interface PropertyTestConstants {
 
+    String LIST_CONTROLLER_NAME = "ObservableListController";
+
     String PROPERTY_CONTROLLER_NAME = "PropertyController";
 
     String PROPERTY_CHANGE_CONTROLLER_NAME = "PropertyChangeController";
 
+    String ADD_ID_ACTION = "addIs";
+
+    String REMOVE_ACTION = "remove";
+
+    String INDEX_PARAM = "index";
+
+    String SIZE_PARAM = "index";
+
+    String CHECK_SIZE_ACTION = "checkSize";
 
     String CHECK_MODEL_CREATION_ACTION = "checkModelCreation";
 

--- a/platform-integration-tests/integration-server/src/main/java/com/canoo/dolphin/integration/server/property/ObservableListController.java
+++ b/platform-integration-tests/integration-server/src/main/java/com/canoo/dolphin/integration/server/property/ObservableListController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2018 Canoo Engineering AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.canoo.dolphin.integration.server.property;
+
+import com.canoo.dolphin.integration.property.ObservableListBean;
+import com.canoo.platform.remoting.server.Param;
+import com.canoo.platform.remoting.server.RemotingAction;
+import com.canoo.platform.remoting.server.RemotingController;
+import com.canoo.platform.remoting.server.RemotingModel;
+
+import java.util.UUID;
+
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.ADD_ID_ACTION;
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.CHECK_SIZE_ACTION;
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.INDEX_PARAM;
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.LIST_CONTROLLER_NAME;
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.REMOVE_ACTION;
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.SIZE_PARAM;
+
+@RemotingController(LIST_CONTROLLER_NAME)
+public class ObservableListController {
+
+    @RemotingModel
+    private ObservableListBean model;
+
+    @RemotingAction(ADD_ID_ACTION)
+    public void addId() {
+        model.getList().add(UUID.randomUUID().toString());
+    }
+
+    @RemotingAction(REMOVE_ACTION)
+    public void remove(@Param(INDEX_PARAM) final int index) {
+        model.getList().remove(index);
+    }
+
+    @RemotingAction(CHECK_SIZE_ACTION)
+    public void checkSize(@Param(SIZE_PARAM) final int size) {
+        if (model.getList().size() == size) {
+            model.setCheckResult(true);
+        } else {
+            model.setCheckResult(false);
+        }
+    }
+
+}

--- a/platform-integration-tests/integration-server/src/test/java/com/canoo/dolphin/integration/server/property/ObservableListControllerTest.java
+++ b/platform-integration-tests/integration-server/src/test/java/com/canoo/dolphin/integration/server/property/ObservableListControllerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2015-2018 Canoo Engineering AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.canoo.dolphin.integration.server.property;
+
+import com.canoo.dolphin.integration.property.ObservableListBean;
+import com.canoo.dolphin.integration.server.TestConfiguration;
+import com.canoo.platform.remoting.client.Param;
+import com.canoo.platform.spring.test.ControllerUnderTest;
+import com.canoo.platform.spring.test.SpringTestNGControllerTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.UUID;
+
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.ADD_ID_ACTION;
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.CHECK_SIZE_ACTION;
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.INDEX_PARAM;
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.LIST_CONTROLLER_NAME;
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.REMOVE_ACTION;
+import static com.canoo.dolphin.integration.property.PropertyTestConstants.SIZE_PARAM;
+
+@SpringBootTest(classes = TestConfiguration.class)
+public class ObservableListControllerTest extends SpringTestNGControllerTest {
+
+    private ControllerUnderTest<ObservableListBean> controller;
+
+    @BeforeMethod
+    public void init() {
+        controller = createController(LIST_CONTROLLER_NAME);
+    }
+
+    @AfterMethod
+    public void destroy() {
+        controller.destroy();
+    }
+
+    @Test
+    public void testControllerCreation() {
+        Assert.assertNotNull(controller);
+    }
+
+    @Test
+    public void testListCreation() {
+        Assert.assertNotNull(controller.getModel().getList());
+    }
+
+    @Test
+    public void testInitialSize() {
+        Assert.assertEquals(controller.getModel().getList().size(), 0);
+        checkSizeOnServer(0);
+    }
+
+    @Test
+    public void testAddOnServer() {
+        controller.invoke(ADD_ID_ACTION);
+        Assert.assertEquals(controller.getModel().getList().size(), 1);
+
+        controller.invoke(ADD_ID_ACTION);
+        controller.invoke(ADD_ID_ACTION);
+        Assert.assertEquals(controller.getModel().getList().size(), 3);
+
+        controller.getModel().getList().forEach(v -> Assert.assertNotNull(v));
+    }
+
+    @Test
+    public void testAddOnClient() {
+        checkSizeOnServer(0);
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+        checkSizeOnServer(1);
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+        checkSizeOnServer(3);
+    }
+
+    @Test
+    public void testRemoveOnServer() {
+        final String s1 = UUID.randomUUID().toString();
+        final String s2 = UUID.randomUUID().toString();
+        final String s3 = UUID.randomUUID().toString();
+
+        controller.getModel().getList().add(s1);
+        controller.getModel().getList().add(s2);
+        controller.getModel().getList().add(s3);
+
+        controller.invoke(REMOVE_ACTION, new Param(INDEX_PARAM, 0));
+        Assert.assertEquals(controller.getModel().getList().size(), 2);
+        Assert.assertTrue(controller.getModel().getList().contains(s2));
+        Assert.assertTrue(controller.getModel().getList().contains(s3));
+
+        controller.invoke(REMOVE_ACTION, new Param(INDEX_PARAM, 1));
+        Assert.assertEquals(controller.getModel().getList().size(), 1);
+        Assert.assertTrue(controller.getModel().getList().contains(s2));
+    }
+
+    @Test
+    public void testRemoveOnClient() {
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+        checkSizeOnServer(3);
+
+        controller.getModel().getList().remove(0);
+        checkSizeOnServer(2);
+
+        controller.getModel().getList().remove(1);
+        checkSizeOnServer(1);
+    }
+
+    @Test
+    public void testRemoveRangeOnClient() {
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+        controller.getModel().getList().add(UUID.randomUUID().toString());
+
+        controller.getModel().getList().remove(0, 3);
+        checkSizeOnServer(2);
+    }
+
+    private void checkSizeOnServer(final int size) {
+        controller.getModel().setCheckResult(false);
+        controller.invoke(CHECK_SIZE_ACTION, new Param(SIZE_PARAM, size));
+        Assert.assertTrue(controller.getModel().getCheckResult());
+    }
+}

--- a/platform/dolphin-platform-remoting-common/src/main/java/com/canoo/dp/impl/remoting/collections/ObservableArrayList.java
+++ b/platform/dolphin-platform-remoting-common/src/main/java/com/canoo/dp/impl/remoting/collections/ObservableArrayList.java
@@ -252,10 +252,8 @@ public class ObservableArrayList<E> implements ObservableList<E> {
     @Override
     public void remove(final int from, final int to)
     {
-        final List<E> oldList = list.subList(from, to);
-        final List<E> copy = new ArrayList<>(oldList);
-        oldList.clear();
-        fireListChanged(new ListChangeEventImpl<>(this, from, to, Collections.unmodifiableList(copy)));
+        final List<E> toRemove = new ArrayList<>(list.subList(from, to));
+        toRemove.forEach(e -> remove(e));
     }
 
     @Override


### PR DESCRIPTION
Currently the Change-Event implementation for observable lists do not allow to delete more than 1 element in a change. Based on this constrain the PR contains a workaround for handling delete(from, to).

A real solution should come with https://github.com/canoo/dolphin-platform/issues/103

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canoo/dolphin-platform/902)
<!-- Reviewable:end -->
